### PR TITLE
Implement foundational risk engine components

### DIFF
--- a/Risk/BaseRisk.cs
+++ b/Risk/BaseRisk.cs
@@ -1,0 +1,52 @@
+using System;
+using NT8.SDK;
+
+namespace NT8.SDK.Risk
+{
+    /// <summary>
+    /// Provides a base implementation for risk rules.
+    /// </summary>
+    public abstract class BaseRisk : IRisk
+    {
+        /// <summary>Initializes a new instance of the <see cref="BaseRisk"/> class.</summary>
+        /// <param name="mode">Risk mode represented by this rule.</param>
+        protected BaseRisk(RiskMode mode)
+        {
+            Mode = mode;
+        }
+
+        /// <summary>Gets the risk mode represented by this rule.</summary>
+        public RiskMode Mode { get; }
+
+        /// <inheritdoc/>
+        public virtual RiskLockoutState Lockout() { return RiskLockoutState.None; }
+
+        /// <inheritdoc/>
+        public virtual bool CanTradeNow() { return true; }
+
+        /// <inheritdoc/>
+        public virtual void RecordWinLoss(bool win) { /* no-op */ }
+
+        /// <inheritdoc/>
+        public abstract string EvaluateEntry(PositionIntent intent);
+    }
+
+#if DEBUG
+    internal sealed class FakeRiskAllow : BaseRisk
+    {
+        public FakeRiskAllow() : base(RiskMode.DCP) { }
+        public override string EvaluateEntry(PositionIntent intent) { return string.Empty; }
+    }
+
+    internal static class DebugBaseRisk
+    {
+        internal static void Main()
+        {
+            var risk = new FakeRiskAllow();
+            Console.WriteLine("Mode: " + risk.Mode);
+            Console.WriteLine("CanTrade: " + risk.CanTradeNow());
+            Console.WriteLine("EvaluateEntry: '" + risk.EvaluateEntry(new PositionIntent("ES", PositionSide.Long)) + "'");
+        }
+    }
+#endif
+}

--- a/Risk/CompositeRisk.cs
+++ b/Risk/CompositeRisk.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Collections.Generic;
+using NT8.SDK;
+
+namespace NT8.SDK.Risk
+{
+    /// <summary>
+    /// Combines multiple <see cref="IRisk"/> implementations into a single composite rule set.
+    /// </summary>
+    public class CompositeRisk : IRisk
+    {
+        private readonly List<IRisk> _rules;
+        private readonly RiskMode _mode;
+
+        /// <summary>Initializes a new instance of the <see cref="CompositeRisk"/> class.</summary>
+        /// <param name="rules">Collection of risk rules. Null becomes empty.</param>
+        /// <param name="mode">Risk mode exposed by this composite.</param>
+        public CompositeRisk(IEnumerable<IRisk> rules, RiskMode mode)
+        {
+            _rules = rules != null ? new List<IRisk>(rules) : new List<IRisk>();
+            _mode = mode;
+        }
+
+        /// <summary>Gets the risk mode exposed by this composite.</summary>
+        public RiskMode Mode { get { return _mode; } }
+
+        /// <inheritdoc/>
+        public string EvaluateEntry(PositionIntent intent)
+        {
+            for (int i = 0; i < _rules.Count; i++)
+            {
+                var reason = _rules[i].EvaluateEntry(intent);
+                if (!string.IsNullOrEmpty(reason)) return reason;
+            }
+            return string.Empty;
+        }
+
+        /// <inheritdoc/>
+        public RiskLockoutState Lockout()
+        {
+            var state = RiskLockoutState.None;
+            for (int i = 0; i < _rules.Count; i++)
+            {
+                var child = _rules[i].Lockout();
+                if (child == RiskLockoutState.LockedOut) return RiskLockoutState.LockedOut;
+                if (child == RiskLockoutState.CoolingDown) state = RiskLockoutState.CoolingDown;
+            }
+            return state;
+        }
+
+        /// <inheritdoc/>
+        public bool CanTradeNow()
+        {
+            for (int i = 0; i < _rules.Count; i++)
+            {
+                if (!_rules[i].CanTradeNow()) return false;
+            }
+            return true;
+        }
+
+        /// <inheritdoc/>
+        public void RecordWinLoss(bool win)
+        {
+            for (int i = 0; i < _rules.Count; i++)
+            {
+                _rules[i].RecordWinLoss(win);
+            }
+        }
+    }
+
+#if DEBUG
+    internal sealed class FakeRiskAllow : IRisk
+    {
+        public RiskMode Mode { get { return RiskMode.DCP; } }
+        public RiskLockoutState Lockout() { return RiskLockoutState.None; }
+        public bool CanTradeNow() { return true; }
+        public string EvaluateEntry(PositionIntent intent) { return string.Empty; }
+        public void RecordWinLoss(bool win) { }
+    }
+
+    internal sealed class FakeRiskBlock : IRisk
+    {
+        private readonly string _reason;
+        public FakeRiskBlock(string reason) { _reason = reason; }
+        public RiskMode Mode { get { return RiskMode.DCP; } }
+        public RiskLockoutState Lockout() { return RiskLockoutState.None; }
+        public bool CanTradeNow() { return true; }
+        public string EvaluateEntry(PositionIntent intent) { return _reason; }
+        public void RecordWinLoss(bool win) { }
+    }
+
+    internal sealed class FakeRiskCooling : IRisk
+    {
+        public RiskMode Mode { get { return RiskMode.DCP; } }
+        public RiskLockoutState Lockout() { return RiskLockoutState.CoolingDown; }
+        public bool CanTradeNow() { return true; }
+        public string EvaluateEntry(PositionIntent intent) { return string.Empty; }
+        public void RecordWinLoss(bool win) { }
+    }
+
+    internal sealed class FakeRiskLocked : IRisk
+    {
+        public RiskMode Mode { get { return RiskMode.DCP; } }
+        public RiskLockoutState Lockout() { return RiskLockoutState.LockedOut; }
+        public bool CanTradeNow() { return true; }
+        public string EvaluateEntry(PositionIntent intent) { return string.Empty; }
+        public void RecordWinLoss(bool win) { }
+    }
+
+    internal static class DebugCompositeRisk
+    {
+        internal static void Main()
+        {
+            var composite = new CompositeRisk(new IRisk[] { new FakeRiskAllow(), new FakeRiskBlock("RULE_X") }, RiskMode.DCP);
+            Console.WriteLine("Entry decision: '" + composite.EvaluateEntry(new PositionIntent("ES", PositionSide.Long)) + "'");
+
+            var cooling = new CompositeRisk(new IRisk[] { new FakeRiskAllow(), new FakeRiskCooling() }, RiskMode.DCP);
+            Console.WriteLine("Lockout state (cooling): " + cooling.Lockout());
+
+            var locked = new CompositeRisk(new IRisk[] { new FakeRiskAllow(), new FakeRiskCooling(), new FakeRiskLocked() }, RiskMode.DCP);
+            Console.WriteLine("Lockout state (locked): " + locked.Lockout());
+        }
+    }
+#endif
+}

--- a/Risk/RiskDecision.cs
+++ b/Risk/RiskDecision.cs
@@ -1,0 +1,50 @@
+using System;
+using NT8.SDK;
+
+namespace NT8.SDK.Risk
+{
+    /// <summary>
+    /// Represents the result of a risk evaluation determining whether an entry is allowed.
+    /// </summary>
+    [Serializable]
+    public struct RiskDecision
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RiskDecision"/> struct.
+        /// </summary>
+        /// <param name="allowEntry">True to allow the entry; otherwise false.</param>
+        /// <param name="reason">Reason for rejection. Ignored when <paramref name="allowEntry"/> is true.</param>
+        /// <param name="riskModeUsed">Risk mode used during evaluation.</param>
+        public RiskDecision(bool allowEntry, string reason, RiskMode riskModeUsed)
+        {
+            AllowEntry = allowEntry;
+            Reason = allowEntry ? string.Empty : (reason ?? string.Empty);
+            RiskModeUsed = riskModeUsed;
+        }
+
+        /// <summary>Gets or sets a value indicating whether the entry is allowed.</summary>
+        public bool AllowEntry { get; set; }
+
+        /// <summary>
+        /// Gets or sets the reason for the decision.
+        /// An empty string indicates acceptance; this value is NEVER null.
+        /// </summary>
+        public string Reason { get; set; }
+
+        /// <summary>Gets or sets the risk mode used during evaluation.</summary>
+        public RiskMode RiskModeUsed { get; set; }
+    }
+
+#if DEBUG
+    internal static class DebugRiskDecision
+    {
+        internal static void Main()
+        {
+            var allowed = new RiskDecision(true, "ignored", RiskMode.DCP);
+            var blocked = new RiskDecision(false, "Too risky", RiskMode.DCP);
+            Console.WriteLine("Allowed Reason: '" + allowed.Reason + "'");
+            Console.WriteLine("Blocked Reason: '" + blocked.Reason + "'");
+        }
+    }
+#endif
+}


### PR DESCRIPTION
## Summary
- Add `using NT8.SDK` directives across risk engine files
- Clarify `RiskDecision.Reason` documentation to guarantee non-null output

## Testing
- `mcs -define:DEBUG -target:library -out:/tmp/RiskDecision.dll Abstractions/*.cs Risk/RiskDecision.cs`
- `mcs -define:DEBUG -target:library -out:/tmp/BaseRisk.dll Abstractions/*.cs Risk/BaseRisk.cs`
- `mcs -define:DEBUG -target:library -out:/tmp/CompositeRisk.dll Abstractions/*.cs Risk/CompositeRisk.cs`


------
https://chatgpt.com/codex/tasks/task_e_689cff12ec008329bad46d20f872bf79