### PR TITLE
Implement basic sizing strategies and rule engine

### DIFF
--- a/Sizing/BracketedQuantitySizing.cs
+++ b/Sizing/BracketedQuantitySizing.cs
@@ -1,0 +1,74 @@
+#if DEBUG
+using System.Diagnostics;
+#endif
+using NT8.SDK;
+
+namespace NT8.SDK.Sizing
+{
+    /// <summary>
+    /// Sizing implementation that selects quantity based on the active risk mode.
+    /// </summary>
+    public class BracketedQuantitySizing : ISizing
+    {
+        private readonly int _ecpQty;
+        private readonly int _pcpQty;
+        private readonly int _dcpQty;
+        private readonly int _hrQty;
+        private readonly string _tag;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BracketedQuantitySizing"/> class.
+        /// </summary>
+        /// <param name="ecpQty">Quantity when risk mode is <see cref="RiskMode.ECP"/>.</param>
+        /// <param name="pcpQty">Quantity when risk mode is <see cref="RiskMode.PCP"/>.</param>
+        /// <param name="dcpQty">Quantity when risk mode is <see cref="RiskMode.DCP"/>.</param>
+        /// <param name="hrQty">Quantity when risk mode is <see cref="RiskMode.HR"/>.</param>
+        /// <param name="tag">Optional tag describing the sizing reason.</param>
+        public BracketedQuantitySizing(int ecpQty, int pcpQty, int dcpQty, int hrQty, string tag = "BracketedQuantity")
+        {
+            _ecpQty = ecpQty;
+            _pcpQty = pcpQty;
+            _dcpQty = dcpQty;
+            _hrQty = hrQty;
+            _tag = tag ?? string.Empty;
+        }
+
+        /// <inheritdoc />
+        public SizeDecision Decide(RiskMode mode, PositionIntent intent)
+        {
+            int qty;
+            switch (mode)
+            {
+                case RiskMode.ECP:
+                    qty = _ecpQty;
+                    break;
+                case RiskMode.PCP:
+                    qty = _pcpQty;
+                    break;
+                case RiskMode.DCP:
+                    qty = _dcpQty;
+                    break;
+                case RiskMode.HR:
+                default:
+                    qty = _hrQty;
+                    break;
+            }
+            return new SizeDecision(qty, _tag, mode);
+        }
+
+#if DEBUG
+        internal static class BracketedQuantitySizingTests
+        {
+            internal static void SmokeTest()
+            {
+                var sizing = new BracketedQuantitySizing(1, 2, 3, 4);
+                var decision = sizing.Decide(RiskMode.HR, new PositionIntent("ES", PositionSide.Long));
+                Debug.Assert(decision.Quantity == 4);
+                Debug.Assert(decision.Reason == "BracketedQuantity");
+                Debug.Assert(decision.RiskModeUsed == RiskMode.HR);
+            }
+        }
+#endif
+    }
+}
+

--- a/Sizing/FixedQuantitySizing.cs
+++ b/Sizing/FixedQuantitySizing.cs
@@ -1,0 +1,48 @@
+#if DEBUG
+using System.Diagnostics;
+#endif
+using NT8.SDK;
+
+namespace NT8.SDK.Sizing
+{
+    /// <summary>
+    /// Sizing implementation that always returns a fixed quantity.
+    /// </summary>
+    public class FixedQuantitySizing : ISizing
+    {
+        private readonly int _quantity;
+        private readonly string _tag;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FixedQuantitySizing"/> class.
+        /// </summary>
+        /// <param name="quantity">The quantity to always return.</param>
+        /// <param name="tag">An optional tag describing the sizing reason.</param>
+        public FixedQuantitySizing(int quantity, string tag = "FixedQuantity")
+        {
+            _quantity = quantity;
+            _tag = tag ?? string.Empty;
+        }
+
+        /// <inheritdoc />
+        public SizeDecision Decide(RiskMode mode, PositionIntent intent)
+        {
+            return new SizeDecision(_quantity, _tag, mode);
+        }
+
+#if DEBUG
+        internal static class FixedQuantitySizingTests
+        {
+            internal static void SmokeTest()
+            {
+                var sizing = new FixedQuantitySizing(10);
+                var decision = sizing.Decide(RiskMode.DCP, new PositionIntent("ES", PositionSide.Long));
+                Debug.Assert(decision.Quantity == 10);
+                Debug.Assert(decision.Reason == "FixedQuantity");
+                Debug.Assert(decision.RiskModeUsed == RiskMode.DCP);
+            }
+        }
+#endif
+    }
+}
+

--- a/Sizing/ISizeRule.cs
+++ b/Sizing/ISizeRule.cs
@@ -1,0 +1,22 @@
+using NT8.SDK;
+
+namespace NT8.SDK.Sizing
+{
+    /// <summary>
+    /// Defines a composable sizing rule that can attempt to produce a sizing decision.
+    /// </summary>
+    public interface ISizeRule
+    {
+        /// <summary>
+        /// Attempts to decide a sizing outcome for the specified risk mode and intent.
+        /// </summary>
+        /// <param name="mode">The active risk mode.</param>
+        /// <param name="intent">The position intent being evaluated.</param>
+        /// <param name="decision">
+        /// When this method returns, contains the decision made by the rule if successful; otherwise the default value.
+        /// </param>
+        /// <returns><c>true</c> if the rule produced a decision; otherwise <c>false</c>.</returns>
+        bool TryDecide(RiskMode mode, PositionIntent intent, out SizeDecision decision);
+    }
+}
+

--- a/Sizing/RuleBasedSizing.cs
+++ b/Sizing/RuleBasedSizing.cs
@@ -1,0 +1,69 @@
+#if DEBUG
+using System.Diagnostics;
+#endif
+using System;
+using System.Collections.Generic;
+using NT8.SDK;
+
+namespace NT8.SDK.Sizing
+{
+    /// <summary>
+    /// Sizing implementation that evaluates a sequence of rules before falling back to a default sizing strategy.
+    /// </summary>
+    public class RuleBasedSizing : ISizing
+    {
+        private readonly List<ISizeRule> _rules;
+        private readonly ISizing _fallback;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RuleBasedSizing"/> class.
+        /// </summary>
+        /// <param name="rules">The ordered set of sizing rules to evaluate.</param>
+        /// <param name="fallback">The fallback sizing to use when no rule provides a decision.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fallback"/> is <c>null</c>.</exception>
+        public RuleBasedSizing(IEnumerable<ISizeRule> rules, ISizing fallback)
+        {
+            if (fallback == null) throw new ArgumentNullException(nameof(fallback));
+            _fallback = fallback;
+            _rules = rules != null ? new List<ISizeRule>(rules) : new List<ISizeRule>();
+        }
+
+        /// <inheritdoc />
+        public SizeDecision Decide(RiskMode mode, PositionIntent intent)
+        {
+            SizeDecision decision;
+            for (int i = 0; i < _rules.Count; i++)
+            {
+                if (_rules[i].TryDecide(mode, intent, out decision))
+                {
+                    return decision;
+                }
+            }
+            return _fallback.Decide(mode, intent);
+        }
+
+#if DEBUG
+        private sealed class InlineRule : ISizeRule
+        {
+            public bool TryDecide(RiskMode mode, PositionIntent intent, out SizeDecision decision)
+            {
+                decision = new SizeDecision(7, "inline", mode);
+                return true;
+            }
+        }
+
+        internal static class RuleBasedSizingTests
+        {
+            internal static void SmokeTest()
+            {
+                var sizing = new RuleBasedSizing(new ISizeRule[] { new InlineRule() }, new FixedQuantitySizing(1));
+                var decision = sizing.Decide(RiskMode.ECP, new PositionIntent("ES", PositionSide.Long));
+                Debug.Assert(decision.Quantity == 7);
+                Debug.Assert(decision.Reason == "inline");
+                Debug.Assert(decision.RiskModeUsed == RiskMode.ECP);
+            }
+        }
+#endif
+    }
+}
+


### PR DESCRIPTION
## Summary
- add ISizeRule interface for composable sizing decisions
- implement FixedQuantitySizing and BracketedQuantitySizing
- introduce RuleBasedSizing to apply ordered rules with fallback

## Testing
- `mcs -target:library Abstractions/Dto.cs Abstractions/ISizing.cs Sizing/ISizeRule.cs Sizing/FixedQuantitySizing.cs Sizing/BracketedQuantitySizing.cs Sizing/RuleBasedSizing.cs`


------
https://chatgpt.com/codex/tasks/task_e_689d0350df688329991642a3660eab8c