### PR TITLE
Add trailing stop strategy abstractions

### DIFF
--- a/Trailing/CompositeTrailingStop.cs
+++ b/Trailing/CompositeTrailingStop.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using NT8.SDK;
+
+namespace NT8.SDK.Trailing
+{
+    /// <summary>
+    /// Aggregates multiple trailing stop strategies and returns the most protective stop.
+    /// </summary>
+    public sealed class CompositeTrailingStop : ITrailingStop
+    {
+        private readonly List<ITrailingStop> _stops;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CompositeTrailingStop"/> class.
+        /// </summary>
+        /// <param name="stops">Collection of child trailing stops. Null becomes empty.</param>
+        public CompositeTrailingStop(IEnumerable<ITrailingStop> stops)
+        {
+            _stops = stops != null ? new List<ITrailingStop>(stops) : new List<ITrailingStop>();
+        }
+
+        /// <inheritdoc />
+        public double? GetStopPrice(double entryPrice, double currentPrice, PositionSide side)
+        {
+            if (side != PositionSide.Long && side != PositionSide.Short) return null;
+
+            double? candidate = null;
+            for (int i = 0; i < _stops.Count; i++)
+            {
+                var value = _stops[i].GetStopPrice(entryPrice, currentPrice, side);
+                if (!value.HasValue) continue;
+                if (!candidate.HasValue)
+                {
+                    candidate = value;
+                }
+                else if (side == PositionSide.Long)
+                {
+                    if (value.Value > candidate.Value) candidate = value;
+                }
+                else
+                {
+                    if (value.Value < candidate.Value) candidate = value;
+                }
+            }
+            return candidate;
+        }
+    }
+
+#if DEBUG
+    internal static class DebugCompositeTrailingStop
+    {
+        internal static void Main()
+        {
+            var composite = new CompositeTrailingStop(new ITrailingStop[]
+            {
+                new FixedTicksTrailingStop(10, 0.25),
+                new PercentTrailingStop(0.1)
+            });
+            Console.WriteLine("Composite long: " + composite.GetStopPrice(100.0, 120.0, PositionSide.Long));
+            Console.WriteLine("Composite short: " + composite.GetStopPrice(100.0, 80.0, PositionSide.Short));
+        }
+    }
+#endif
+}

--- a/Trailing/FixedTicksTrailingStop.cs
+++ b/Trailing/FixedTicksTrailingStop.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Diagnostics;
+using NT8.SDK;
+
+namespace NT8.SDK.Trailing
+{
+    /// <summary>
+    /// Trailing stop that tracks price using a fixed number of ticks.
+    /// </summary>
+    public sealed class FixedTicksTrailingStop : ITrailingStop
+    {
+        private readonly int _ticks;
+        private readonly double _tickSize;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FixedTicksTrailingStop"/> class.
+        /// </summary>
+        /// <param name="ticks">The number of ticks for the stop distance.</param>
+        /// <param name="tickSize">The size of a single tick.</param>
+        public FixedTicksTrailingStop(int ticks, double tickSize)
+        {
+            _ticks = ticks;
+            _tickSize = tickSize;
+        }
+
+        /// <inheritdoc />
+        public double? GetStopPrice(double entryPrice, double currentPrice, PositionSide side)
+        {
+            if (_ticks <= 0 || _tickSize <= 0.0) return null;
+
+            double offset = _ticks * _tickSize;
+            if (side == PositionSide.Long)
+            {
+                double fromEntry = entryPrice - offset;
+                double fromCurrent = currentPrice - offset;
+                return Math.Max(fromEntry, fromCurrent);
+            }
+            if (side == PositionSide.Short)
+            {
+                double fromEntry = entryPrice + offset;
+                double fromCurrent = currentPrice + offset;
+                return Math.Min(fromEntry, fromCurrent);
+            }
+            return null;
+        }
+    }
+
+#if DEBUG
+    internal static class DebugFixedTicksTrailingStop
+    {
+        internal static void Main()
+        {
+            var stop = new FixedTicksTrailingStop(10, 0.25);
+            double? longStop = stop.GetStopPrice(100.0, 110.0, PositionSide.Long);
+            double? shortStop = stop.GetStopPrice(100.0, 90.0, PositionSide.Short);
+            Debug.Assert(longStop.HasValue && Math.Abs(longStop.Value - 107.5) < 0.0001);
+            Debug.Assert(shortStop.HasValue && Math.Abs(shortStop.Value - 92.5) < 0.0001);
+            Console.WriteLine("FixedTicksTrailingStop smoke test passed");
+        }
+    }
+#endif
+}

--- a/Trailing/ITrailingStop.cs
+++ b/Trailing/ITrailingStop.cs
@@ -1,0 +1,40 @@
+using System;
+using NT8.SDK;
+
+namespace NT8.SDK.Trailing
+{
+    /// <summary>
+    /// Defines a trailing stop strategy that suggests stop prices based on
+    /// entry and current prices.
+    /// </summary>
+    public interface ITrailingStop
+    {
+        /// <summary>
+        /// Gets a suggested stop price.
+        /// </summary>
+        /// <param name="entryPrice">The original entry price.</param>
+        /// <param name="currentPrice">The current market price.</param>
+        /// <param name="side">The side of the position.</param>
+        /// <returns>The suggested stop price, or <c>null</c> if inactive or cannot compute.</returns>
+        double? GetStopPrice(double entryPrice, double currentPrice, PositionSide side);
+    }
+
+#if DEBUG
+    internal sealed class DebugTrailingStop : ITrailingStop
+    {
+        public double? GetStopPrice(double entryPrice, double currentPrice, PositionSide side)
+        {
+            return currentPrice;
+        }
+    }
+
+    internal static class DebugITrailingStop
+    {
+        internal static void Main()
+        {
+            ITrailingStop stop = new DebugTrailingStop();
+            Console.WriteLine("Debug stop: " + stop.GetStopPrice(1.0, 2.0, PositionSide.Long));
+        }
+    }
+#endif
+}

--- a/Trailing/PercentTrailingStop.cs
+++ b/Trailing/PercentTrailingStop.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Diagnostics;
+using NT8.SDK;
+
+namespace NT8.SDK.Trailing
+{
+    /// <summary>
+    /// Trailing stop that tracks price using a percentage move.
+    /// </summary>
+    public sealed class PercentTrailingStop : ITrailingStop
+    {
+        private readonly double _percent;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PercentTrailingStop"/> class.
+        /// </summary>
+        /// <param name="percent">Fractional percent (e.g., 0.01 for 1%).</param>
+        public PercentTrailingStop(double percent)
+        {
+            _percent = percent;
+        }
+
+        /// <inheritdoc />
+        public double? GetStopPrice(double entryPrice, double currentPrice, PositionSide side)
+        {
+            if (_percent <= 0.0) return null;
+
+            double factor = _percent;
+            if (side == PositionSide.Long)
+            {
+                double fromEntry = entryPrice * (1.0 - factor);
+                double fromCurrent = currentPrice * (1.0 - factor);
+                return Math.Max(fromEntry, fromCurrent);
+            }
+            if (side == PositionSide.Short)
+            {
+                double fromEntry = entryPrice * (1.0 + factor);
+                double fromCurrent = currentPrice * (1.0 + factor);
+                return Math.Min(fromEntry, fromCurrent);
+            }
+            return null;
+        }
+    }
+
+#if DEBUG
+    internal static class DebugPercentTrailingStop
+    {
+        internal static void Main()
+        {
+            var stop = new PercentTrailingStop(0.1);
+            double? longStop = stop.GetStopPrice(100.0, 120.0, PositionSide.Long);
+            double? shortStop = stop.GetStopPrice(100.0, 80.0, PositionSide.Short);
+            Debug.Assert(longStop.HasValue && Math.Abs(longStop.Value - 108.0) < 0.0001);
+            Debug.Assert(shortStop.HasValue && Math.Abs(shortStop.Value - 88.0) < 0.0001);
+            Console.WriteLine("PercentTrailingStop smoke test passed");
+        }
+    }
+#endif
+}


### PR DESCRIPTION
## Summary
- add `ITrailingStop` interface and basic implementations
- implement fixed-ticks and percent trailing stop strategies
- compose multiple trailing stops via `CompositeTrailingStop`

## Testing
- `mcs -define:DEBUG -out:/tmp/ft.exe Trailing/FixedTicksTrailingStop.cs Trailing/PercentTrailingStop.cs Trailing/CompositeTrailingStop.cs Trailing/ITrailingStop.cs Abstractions/Dto.cs -main:NT8.SDK.Trailing.DebugFixedTicksTrailingStop`
- `mono /tmp/ft.exe`
- `mcs -define:DEBUG -out:/tmp/pt.exe Trailing/PercentTrailingStop.cs Trailing/FixedTicksTrailingStop.cs Trailing/CompositeTrailingStop.cs Trailing/ITrailingStop.cs Abstractions/Dto.cs -main:NT8.SDK.Trailing.DebugPercentTrailingStop`
- `mono /tmp/pt.exe`
- `mcs -define:DEBUG -out:/tmp/ct.exe Trailing/CompositeTrailingStop.cs Trailing/PercentTrailingStop.cs Trailing/FixedTicksTrailingStop.cs Trailing/ITrailingStop.cs Abstractions/Dto.cs -main:NT8.SDK.Trailing.DebugCompositeTrailingStop`
- `mono /tmp/ct.exe`
- `mcs -define:DEBUG -out:/tmp/it.exe Trailing/ITrailingStop.cs Abstractions/Dto.cs -main:NT8.SDK.Trailing.DebugITrailingStop`
- `mono /tmp/it.exe`


------
https://chatgpt.com/codex/tasks/task_e_689d054037e0832986eeb4167fd4e07f