### PR TITLE
Implement in-memory telemetry, diagnostics, and trailing adapter

### DIFF
--- a/Diagnostics/InMemoryDiagnostics.cs
+++ b/Diagnostics/InMemoryDiagnostics.cs
@@ -1,0 +1,64 @@
+using System;
+using NT8.SDK;
+
+namespace NT8.SDK.Diagnostics
+{
+    /// <summary>
+    /// In-memory diagnostics capture that stores recent events in a bounded ring buffer.
+    /// </summary>
+    public sealed class InMemoryDiagnostics : IDiagnostics
+    {
+        private readonly DiagnosticsEvent[] _buffer;
+        private readonly object _sync = new object();
+        private int _next;
+        private int _count;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InMemoryDiagnostics"/> class.
+        /// </summary>
+        /// <param name="capacity">Maximum number of events to retain.</param>
+        public InMemoryDiagnostics(int capacity = 512)
+        {
+            if (capacity < 1) capacity = 1;
+            _buffer = new DiagnosticsEvent[capacity];
+        }
+
+        /// <inheritdoc />
+        public bool Enabled { get; set; }
+
+        /// <inheritdoc />
+        public void Capture(object snapshot, string tag)
+        {
+            if (!Enabled) return;
+
+            DiagnosticsEvent evt = new DiagnosticsEvent(tag ?? string.Empty, snapshot != null ? snapshot.ToString() : string.Empty);
+            lock (_sync)
+            {
+                _buffer[_next] = evt;
+                _next = (_next + 1) % _buffer.Length;
+                if (_count < _buffer.Length) _count++;
+            }
+        }
+
+        /// <summary>
+        /// Gets a snapshot of the captured diagnostic events.
+        /// </summary>
+        /// <returns>Events in chronological order (most recent last).</returns>
+        public DiagnosticsEvent[] Snapshot()
+        {
+            lock (_sync)
+            {
+                DiagnosticsEvent[] result = new DiagnosticsEvent[_count];
+                int cap = _buffer.Length;
+                int start = (_next - _count + cap) % cap;
+                for (int i = 0; i < _count; i++)
+                {
+                    int idx = (start + i) % cap;
+                    result[i] = _buffer[idx];
+                }
+                return result;
+            }
+        }
+    }
+}
+

--- a/Diagnostics/NullDiagnostics.cs
+++ b/Diagnostics/NullDiagnostics.cs
@@ -1,0 +1,19 @@
+using NT8.SDK;
+
+namespace NT8.SDK.Diagnostics
+{
+    /// <summary>
+    /// No-op diagnostics capture that discards all input snapshots.
+    /// </summary>
+    public sealed class NullDiagnostics : IDiagnostics
+    {
+        /// <inheritdoc />
+        public bool Enabled { get; set; }
+
+        /// <inheritdoc />
+        public void Capture(object snapshot, string tag)
+        {
+        }
+    }
+}
+

--- a/Telemetry/InMemoryTelemetry.cs
+++ b/Telemetry/InMemoryTelemetry.cs
@@ -1,0 +1,58 @@
+using System;
+using NT8.SDK;
+
+namespace NT8.SDK.Telemetry
+{
+    /// <summary>
+    /// In-memory telemetry service that stores a bounded log of recent telemetry events.
+    /// </summary>
+    public sealed class InMemoryTelemetry : ITelemetry
+    {
+        private readonly TelemetryEvent[] _buffer;
+        private readonly object _sync = new object();
+        private int _next;
+        private int _count;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InMemoryTelemetry"/> class.
+        /// </summary>
+        /// <param name="capacity">Maximum number of events to retain.</param>
+        public InMemoryTelemetry(int capacity = 512)
+        {
+            if (capacity < 1) capacity = 1;
+            _buffer = new TelemetryEvent[capacity];
+        }
+
+        /// <inheritdoc />
+        public void Emit(TelemetryEvent evt)
+        {
+            lock (_sync)
+            {
+                _buffer[_next] = evt;
+                _next = (_next + 1) % _buffer.Length;
+                if (_count < _buffer.Length) _count++;
+            }
+        }
+
+        /// <summary>
+        /// Gets a snapshot of the currently stored telemetry events.
+        /// </summary>
+        /// <returns>Events in chronological order (most recent last).</returns>
+        public TelemetryEvent[] Snapshot()
+        {
+            lock (_sync)
+            {
+                TelemetryEvent[] result = new TelemetryEvent[_count];
+                int cap = _buffer.Length;
+                int start = (_next - _count + cap) % cap;
+                for (int i = 0; i < _count; i++)
+                {
+                    int idx = (start + i) % cap;
+                    result[i] = _buffer[idx];
+                }
+                return result;
+            }
+        }
+    }
+}
+

--- a/Telemetry/NullTelemetry.cs
+++ b/Telemetry/NullTelemetry.cs
@@ -1,0 +1,16 @@
+using NT8.SDK;
+
+namespace NT8.SDK.Telemetry
+{
+    /// <summary>
+    /// No-op telemetry implementation that silently drops all events.
+    /// </summary>
+    public sealed class NullTelemetry : ITelemetry
+    {
+        /// <inheritdoc />
+        public void Emit(TelemetryEvent evt)
+        {
+        }
+    }
+}
+

--- a/Trailing/TrailingAdapter.cs
+++ b/Trailing/TrailingAdapter.cs
@@ -1,0 +1,88 @@
+using System;
+using NT8.SDK;
+
+namespace NT8.SDK.Trailing
+{
+    /// <summary>
+    /// Adapter that bridges an <see cref="ITrailingStop"/> strategy to the <see cref="ITrailing"/> interface.
+    /// </summary>
+    public sealed class TrailingAdapter : ITrailing
+    {
+        private readonly ITrailingStop _stop;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TrailingAdapter"/> class.
+        /// </summary>
+        /// <param name="stop">Underlying trailing stop strategy.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="stop"/> is <c>null</c>.</exception>
+        public TrailingAdapter(ITrailingStop stop)
+        {
+            if (stop == null) throw new ArgumentNullException("stop");
+            _stop = stop;
+        }
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// The <paramref name="profile"/> parameter is currently ignored.
+        /// </remarks>
+        public decimal ComputeStop(decimal entry, decimal current, bool isLong, TrailingProfile profile, decimal priorStop)
+        {
+            double entryD = (double)entry;
+            double currentD = (double)current;
+            PositionSide side = isLong ? PositionSide.Long : PositionSide.Short;
+            double? candidate = _stop.GetStopPrice(entryD, currentD, side);
+            if (!candidate.HasValue) return priorStop;
+
+            decimal candidateDec;
+            try
+            {
+                candidateDec = (decimal)candidate.Value;
+            }
+            catch
+            {
+                return priorStop;
+            }
+
+            if (isLong)
+            {
+                return priorStop > candidateDec ? priorStop : candidateDec;
+            }
+            return priorStop < candidateDec ? priorStop : candidateDec;
+        }
+    }
+
+#if DEBUG
+    internal static class DebugTrailingAdapter
+    {
+        private sealed class DummyStop : ITrailingStop
+        {
+            public double? GetStopPrice(double entryPrice, double currentPrice, PositionSide side)
+            {
+                if (side == PositionSide.Long) return currentPrice - 1.0;
+                if (side == PositionSide.Short) return currentPrice + 1.0;
+                return null;
+            }
+        }
+
+        internal static void Main()
+        {
+            ITrailingStop stop = new DummyStop();
+            var adapter = new TrailingAdapter(stop);
+            TrailingProfile profile = new TrailingProfile();
+
+            decimal priorLong = 100m;
+            decimal longStop1 = adapter.ComputeStop(100m, 120m, true, profile, priorLong);
+            decimal longStop2 = adapter.ComputeStop(100m, 110m, true, profile, longStop1);
+            System.Diagnostics.Debug.Assert(longStop2 >= longStop1);
+
+            decimal priorShort = 100m;
+            decimal shortStop1 = adapter.ComputeStop(100m, 80m, false, profile, priorShort);
+            decimal shortStop2 = adapter.ComputeStop(100m, 90m, false, profile, shortStop1);
+            System.Diagnostics.Debug.Assert(shortStop2 <= shortStop1);
+
+            Console.WriteLine("TrailingAdapter smoke test completed");
+        }
+    }
+#endif
+}
+


### PR DESCRIPTION
## Summary
- add ring-buffer based in-memory telemetry and diagnostics services with no-op variants
- bridge ITrailingStop strategies to ITrailing via adapter enforcing non-loosening semantics

## Testing
- `mcs -langversion:7.2 -target:library Abstractions/Dto.cs Abstractions/ITelemetry.cs Abstractions/IDiagnostics.cs Abstractions/ITrailing.cs Trailing/ITrailingStop.cs Trailing/TrailingAdapter.cs Telemetry/InMemoryTelemetry.cs Telemetry/NullTelemetry.cs Diagnostics/InMemoryDiagnostics.cs Diagnostics/NullDiagnostics.cs -out:/tmp/sdk.dll`


------
https://chatgpt.com/codex/tasks/task_e_689d07c20b10832992fb369789965dda