### PR TITLE
Step 7 — Facade & Adapter (pure C#)

### DIFF
--- a/Facade/SdkAdapterV1.cs
+++ b/Facade/SdkAdapterV1.cs
@@ -1,0 +1,64 @@
+using System;
+using NT8.SDK;
+
+namespace NT8.SDK.Facade
+{
+    /// <summary>
+    /// Fluent builder for constructing an <see cref="ISdk"/> facade from components.
+    /// </summary>
+    public sealed class SdkAdapterV1
+    {
+        private IRisk _risk;
+        private ISizing _sizing;
+        private IOrders _orders;
+        private ISession _session;
+        private ITrailing _trailing;
+        private ITelemetry _telemetry;
+        private IDiagnostics _diagnostics;
+        private IBacktestHooks _backtest;
+
+        /// <summary>Sets the risk engine.</summary>
+        public SdkAdapterV1 WithRisk(IRisk risk) { _risk = risk; return this; }
+
+        /// <summary>Sets the sizing engine.</summary>
+        public SdkAdapterV1 WithSizing(ISizing sizing) { _sizing = sizing; return this; }
+
+        /// <summary>Sets the order router.</summary>
+        public SdkAdapterV1 WithOrders(IOrders orders) { _orders = orders; return this; }
+
+        /// <summary>Sets the session service.</summary>
+        public SdkAdapterV1 WithSession(ISession session) { _session = session; return this; }
+
+        /// <summary>Sets the trailing service.</summary>
+        public SdkAdapterV1 WithTrailing(ITrailing trailing) { _trailing = trailing; return this; }
+
+        /// <summary>Sets the telemetry sink.</summary>
+        public SdkAdapterV1 WithTelemetry(ITelemetry telemetry) { _telemetry = telemetry; return this; }
+
+        /// <summary>Sets the diagnostics sink.</summary>
+        public SdkAdapterV1 WithDiagnostics(IDiagnostics diagnostics) { _diagnostics = diagnostics; return this; }
+
+        /// <summary>Sets the backtest hooks.</summary>
+        public SdkAdapterV1 WithBacktest(IBacktestHooks backtest) { _backtest = backtest; return this; }
+
+        /// <summary>
+        /// Builds a facade and a matching capabilities descriptor.
+        /// </summary>
+        public SdkFacade Build(out SdkCapabilities caps)
+        {
+            var facade = new SdkFacade(_risk, _sizing, _orders, _session, _trailing, _telemetry, _diagnostics, _backtest);
+            caps = new SdkCapabilities
+            {
+                HasRisk = _risk != null,
+                HasSizing = _sizing != null,
+                HasOrders = _orders != null,
+                HasSession = _session != null,
+                HasTrailing = _trailing != null,
+                HasTelemetry = _telemetry != null,
+                HasDiagnostics = _diagnostics != null,
+                HasBacktest = _backtest != null
+            };
+            return facade;
+        }
+    }
+}

--- a/Facade/SdkCapabilities.cs
+++ b/Facade/SdkCapabilities.cs
@@ -1,0 +1,35 @@
+using System;
+using NT8.SDK;
+
+namespace NT8.SDK.Facade
+{
+    /// <summary>
+    /// Describes which subsystems are present in a built SDK instance.
+    /// </summary>
+    public sealed class SdkCapabilities
+    {
+        /// <summary>True when the facade has a non-null risk engine.</summary>
+        public bool HasRisk { get; set; }
+
+        /// <summary>True when the facade has a non-null sizing engine.</summary>
+        public bool HasSizing { get; set; }
+
+        /// <summary>True when the facade has a non-null order router.</summary>
+        public bool HasOrders { get; set; }
+
+        /// <summary>True when the facade has a non-null session service.</summary>
+        public bool HasSession { get; set; }
+
+        /// <summary>True when the facade has a non-null trailing service.</summary>
+        public bool HasTrailing { get; set; }
+
+        /// <summary>True when the facade has a non-null telemetry sink.</summary>
+        public bool HasTelemetry { get; set; }
+
+        /// <summary>True when the facade has a non-null diagnostics sink.</summary>
+        public bool HasDiagnostics { get; set; }
+
+        /// <summary>True when the facade has a non-null backtest hooks object.</summary>
+        public bool HasBacktest { get; set; }
+    }
+}

--- a/Facade/SdkFacade.cs
+++ b/Facade/SdkFacade.cs
@@ -1,0 +1,51 @@
+using System;
+using NT8.SDK;
+
+/// <summary>
+/// Concrete implementation of ISdk that aggregates core subsystems.
+/// </summary>
+namespace NT8.SDK.Facade
+{
+    /// <summary>
+    /// Concrete implementation of <see cref="ISdk"/> that aggregates core subsystems.
+    /// </summary>
+    public sealed class SdkFacade : ISdk
+    {
+        /// <summary>Constructs an immutable facade over the provided subsystems (nulls allowed).</summary>
+        public SdkFacade(IRisk risk, ISizing sizing, IOrders orders, ISession session, ITrailing trailing, ITelemetry telemetry, IDiagnostics diagnostics, IBacktestHooks backtest)
+        {
+            Risk = risk;
+            Sizing = sizing;
+            Orders = orders;
+            Session = session;
+            Trailing = trailing;
+            Telemetry = telemetry;
+            Diagnostics = diagnostics;
+            Backtest = backtest;
+        }
+
+        /// <inheritdoc/>
+        public IRisk Risk { get; private set; }
+
+        /// <inheritdoc/>
+        public ISizing Sizing { get; private set; }
+
+        /// <inheritdoc/>
+        public IOrders Orders { get; private set; }
+
+        /// <inheritdoc/>
+        public ISession Session { get; private set; }
+
+        /// <inheritdoc/>
+        public ITrailing Trailing { get; private set; }
+
+        /// <inheritdoc/>
+        public ITelemetry Telemetry { get; private set; }
+
+        /// <inheritdoc/>
+        public IDiagnostics Diagnostics { get; private set; }
+
+        /// <inheritdoc/>
+        public IBacktestHooks Backtest { get; private set; }
+    }
+}


### PR DESCRIPTION
## Summary
- Implement facade `SdkFacade` assembling core subsystems behind the `ISdk` interface.
- Add `SdkCapabilities` descriptor indicating which subsystems are wired.
- Introduce fluent builder `SdkAdapterV1` to construct `SdkFacade` and capabilities together.

## Testing
- `python tools/nt8_guard.py --fail-on-warn`

------
https://chatgpt.com/codex/tasks/task_e_689d0ce1743483298fa7f71a74924f47