### PR TITLE
Step 9 — Common risk utilities

### DIFF
--- a/Common/LossStreakGuard.cs
+++ b/Common/LossStreakGuard.cs
@@ -1,0 +1,79 @@
+using System;
+using NT8.SDK;
+
+namespace NT8.SDK.Common
+{
+    /// <summary>
+    /// IRisk guard that blocks new entries after a configured number of consecutive losses.
+    /// Resets the streak on a win.
+    /// </summary>
+    public sealed class LossStreakGuard : IRisk
+    {
+        private readonly int _maxLosses;
+        private readonly string _reasonTag;
+        private readonly RiskMode _mode;
+        private int _lossStreak;
+
+        /// <summary>
+        /// Creates a new loss-streak guard.
+        /// </summary>
+        /// <param name="maxLosses">Maximum consecutive losses allowed before blocking entries (>= 1).</param>
+        /// <param name="mode">Risk mode reported by this guard.</param>
+        /// <param name="reasonTag">Reason text returned by <see cref="EvaluateEntry"/> when blocked.</param>
+        public LossStreakGuard(int maxLosses, RiskMode mode, string reasonTag = "LossStreak")
+        {
+            _maxLosses = maxLosses < 1 ? 1 : maxLosses;
+            _mode = mode;
+            _reasonTag = reasonTag ?? string.Empty;
+            _lossStreak = 0;
+        }
+
+        /// <inheritdoc/>
+        public RiskMode Mode { get { return _mode; } }
+
+        /// <inheritdoc/>
+        public RiskLockoutState Lockout()
+        {
+            return _lossStreak >= _maxLosses ? RiskLockoutState.LockedOut : RiskLockoutState.None;
+        }
+
+        /// <inheritdoc/>
+        public bool CanTradeNow()
+        {
+            return _lossStreak < _maxLosses;
+        }
+
+        /// <inheritdoc/>
+        /// <remarks>Return EMPTY STRING ("") when accepted; otherwise a reason tag.</remarks>
+        public string EvaluateEntry(PositionIntent intent)
+        {
+            return _lossStreak >= _maxLosses ? _reasonTag : string.Empty;
+        }
+
+        /// <inheritdoc/>
+        public void RecordWinLoss(bool win)
+        {
+            if (win) _lossStreak = 0;
+            else _lossStreak++;
+        }
+
+#if DEBUG
+        internal static class LossStreakGuardTests
+        {
+            internal static void Smoke()
+            {
+                var g = new LossStreakGuard(2, RiskMode.DCP);
+                System.Diagnostics.Debug.Assert(g.EvaluateEntry(new PositionIntent("ES", PositionSide.Long)) == "");
+                g.RecordWinLoss(false);
+                System.Diagnostics.Debug.Assert(g.CanTradeNow());
+                g.RecordWinLoss(false);
+                System.Diagnostics.Debug.Assert(!g.CanTradeNow());
+                System.Diagnostics.Debug.Assert(g.EvaluateEntry(new PositionIntent("ES", PositionSide.Long)) != "");
+                g.RecordWinLoss(true);
+                System.Diagnostics.Debug.Assert(g.CanTradeNow());
+            }
+        }
+#endif
+    }
+}
+

--- a/Common/PnLTracker.cs
+++ b/Common/PnLTracker.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections.Generic;
+
+namespace NT8.SDK.Common
+{
+    /// <summary>
+    /// Simple per-symbol P&amp;L tracker with average price accounting.
+    /// Positive position = long, negative = short. Pure math (no broker/NT8 types).
+    /// </summary>
+    public sealed class PnLTracker
+    {
+        private sealed class State
+        {
+            public int Qty;            // signed quantity; >0 long, <0 short
+            public decimal AvgPrice;   // average price of open position
+            public decimal Realized;   // cumulative realized PnL
+        }
+
+        private readonly Dictionary<string, State> _bySymbol = new Dictionary<string, State>(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>Resets all symbols.</summary>
+        public void Reset() { _bySymbol.Clear(); }
+
+        /// <summary>Returns the signed position quantity for a symbol (0 if none).</summary>
+        public int Position(string symbol) { return Get(symbol).Qty; }
+
+        /// <summary>Returns the average price of the open position (0 if flat).</summary>
+        public decimal AvgPrice(string symbol) { return Get(symbol).Qty == 0 ? 0m : Get(symbol).AvgPrice; }
+
+        /// <summary>Returns cumulative realized PnL for the symbol.</summary>
+        public decimal Realized(string symbol) { return Get(symbol).Realized; }
+
+        /// <summary>
+        /// Returns unrealized PnL given a current price and an optional point value (multiplier).
+        /// </summary>
+        public decimal Unrealized(string symbol, decimal currentPrice, decimal pointValue)
+        {
+            var s = Get(symbol);
+            if (s.Qty == 0) return 0m;
+            var diff = (currentPrice - s.AvgPrice);
+            if (s.Qty < 0) diff = -diff; // short gains when price falls
+            return diff * Math.Abs(s.Qty) * pointValue;
+        }
+
+        /// <summary>
+        /// Processes a fill. isBuy=true for buy, false for sell. Quantity must be &gt; 0.
+        /// Uses FIFO-like average price accounting.
+        /// </summary>
+        public void OnFill(string symbol, bool isBuy, int quantity, decimal price, decimal pointValue)
+        {
+            if (quantity <= 0) return;
+            var s = Get(symbol);
+            int signed = isBuy ? quantity : -quantity;
+
+            // If adding to same direction, update weighted average.
+            if ((s.Qty >= 0 && signed > 0) || (s.Qty <= 0 && signed < 0))
+            {
+                int newQty = s.Qty + signed;
+                if (s.Qty == 0)
+                {
+                    s.AvgPrice = price;
+                }
+                else
+                {
+                    decimal notional = (s.AvgPrice * Math.Abs(s.Qty)) + (price * Math.Abs(signed));
+                    s.AvgPrice = notional / (Math.Abs(newQty));
+                }
+                s.Qty = newQty;
+                return;
+            }
+
+            // Opposite direction: realize PnL up to flatten or flip
+            int closeQty = Math.Min(Math.Abs(s.Qty), Math.Abs(signed));
+            if (closeQty > 0)
+            {
+                decimal pnlPerUnit = (price - s.AvgPrice);
+                if (s.Qty < 0) pnlPerUnit = -pnlPerUnit; // short: profits when price < avg
+                s.Realized += pnlPerUnit * closeQty * pointValue;
+                s.Qty += isBuy ? closeQty : -closeQty; // closing portion reduces magnitude
+            }
+
+            // If flip remains, reset avg on the new side
+            int remaining = signed + (isBuy ? -closeQty : closeQty);
+            if (remaining != 0)
+            {
+                s.AvgPrice = price;
+                s.Qty += remaining;
+            }
+            else if (s.Qty == 0)
+            {
+                s.AvgPrice = 0m;
+            }
+        }
+
+        private State Get(string symbol)
+        {
+            State s;
+            if (!_bySymbol.TryGetValue(symbol, out s))
+            {
+                s = new State();
+                _bySymbol[symbol] = s;
+            }
+            return s;
+        }
+
+#if DEBUG
+        internal static class PnLTrackerTests
+        {
+            internal static void Smoke()
+            {
+                var t = new PnLTracker();
+                t.OnFill("ES", true, 2, 100m, 1m);     // long 2 @100
+                t.OnFill("ES", false, 1, 105m, 1m);    // close 1 @105 → +5
+                System.Diagnostics.Debug.Assert(t.Realized("ES") == 5m);
+                System.Diagnostics.Debug.Assert(t.Position("ES") == 1);
+                System.Diagnostics.Debug.Assert(t.Unrealized("ES", 104m, 1m) == 4m);
+            }
+        }
+#endif
+    }
+}
+

--- a/Common/RiskManager.cs
+++ b/Common/RiskManager.cs
@@ -1,0 +1,68 @@
+using System;
+using NT8.SDK;
+
+namespace NT8.SDK.Common
+{
+    /// <summary>
+    /// IRisk wrapper that adds enable/disable and manual lockout around an inner risk engine.
+    /// If disabled, entries are blocked with reason "RiskDisabled".
+    /// If manual lockout is set, entries are blocked with reason "RiskManualLockout".
+    /// </summary>
+    public sealed class RiskManager : IRisk
+    {
+        private readonly IRisk _inner;
+        private readonly RiskMode _mode;
+
+        /// <summary>True to enable risk checks; false to block all entries.</summary>
+        public bool Enabled { get; set; }
+
+        /// <summary>True to force lockout regardless of inner state.</summary>
+        public bool ManualLockout { get; set; }
+
+        /// <summary>
+        /// Creates a new risk manager.
+        /// </summary>
+        /// <param name="inner">Inner risk engine (can be a composite). May be null.</param>
+        /// <param name="mode">Mode reported by this manager; defaults to inner.Mode if inner provided.</param>
+        public RiskManager(IRisk inner, RiskMode mode)
+        {
+            _inner = inner;
+            _mode = mode;
+            Enabled = true;
+            ManualLockout = false;
+        }
+
+        /// <inheritdoc/>
+        public RiskMode Mode { get { return _mode; } }
+
+        /// <inheritdoc/>
+        public RiskLockoutState Lockout()
+        {
+            if (!Enabled || ManualLockout) return RiskLockoutState.LockedOut;
+            return _inner != null ? _inner.Lockout() : RiskLockoutState.None;
+        }
+
+        /// <inheritdoc/>
+        public bool CanTradeNow()
+        {
+            if (!Enabled || ManualLockout) return false;
+            return _inner != null ? _inner.CanTradeNow() : true;
+        }
+
+        /// <inheritdoc/>
+        /// <remarks>Return EMPTY STRING ("") when accepted; otherwise a reason string.</remarks>
+        public string EvaluateEntry(PositionIntent intent)
+        {
+            if (!Enabled) return "RiskDisabled";
+            if (ManualLockout) return "RiskManualLockout";
+            return _inner != null ? _inner.EvaluateEntry(intent) : string.Empty;
+        }
+
+        /// <inheritdoc/>
+        public void RecordWinLoss(bool win)
+        {
+            if (_inner != null) _inner.RecordWinLoss(win);
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add LossStreakGuard to prevent entries after too many consecutive losses
- introduce RiskManager wrapper with enable and manual lockout toggles
- implement PnLTracker for per-symbol realized and unrealized P&L with average price tracking

## Testing
- `mcs -target:library -langversion:7.2 @/tmp/sources.txt -r:System.Web.Extensions.dll -out:/tmp/nt8.dll`


------
https://chatgpt.com/codex/tasks/task_e_689d107715908329bab357e05699e9a9