### PR TITLE
Step 10 — Common: TrailProfiles + PositionSizer + OrderRouter

### DIFF
--- a/Common/OrderRouter.cs
+++ b/Common/OrderRouter.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using NT8.SDK;
+
+namespace NT8.SDK.Common
+{
+    /// <summary>
+    /// Pure C# in-memory order router implementing <see cref="IOrders"/>.
+    /// Generates synthetic order IDs and keeps a small log for diagnostics.
+    /// This is a placeholder for platforms that do not provide a broker bridge.
+    /// </summary>
+    public sealed class OrderRouter : IOrders
+    {
+        private readonly List<OrderIntent> _log = new List<OrderIntent>();
+        private readonly object _sync = new object();
+
+        /// <summary>Maximum number of intents to retain in memory.</summary>
+        public int Capacity { get; private set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OrderRouter"/> class.
+        /// </summary>
+        /// <param name="capacity">Maximum number of intents kept in memory.</param>
+        public OrderRouter(int capacity = 512)
+        {
+            if (capacity < 1) capacity = 1;
+            Capacity = capacity;
+        }
+
+        /// <inheritdoc/>
+        public OrderIds Submit(OrderIntent intent)
+        {
+            lock (_sync) Enqueue(intent);
+            string stamp = DateTime.UtcNow.Ticks.ToString();
+            string baseId = (intent.Signal ?? "ORD") + "-" + stamp;
+            return new OrderIds(baseId + "-E", baseId + "-S", baseId + "-T");
+        }
+
+        /// <inheritdoc/>
+        public bool Cancel(OrderIds ids)
+        {
+            return true;
+        }
+
+        /// <inheritdoc/>
+        public bool Modify(OrderIds ids, OrderIntent intent)
+        {
+            lock (_sync) Enqueue(intent);
+            return false;
+        }
+
+        /// <summary>
+        /// Returns a snapshot copy of the current intent log.
+        /// </summary>
+        public OrderIntent[] Snapshot()
+        {
+            lock (_sync)
+            {
+                return _log.ToArray();
+            }
+        }
+
+        private void Enqueue(OrderIntent intent)
+        {
+            _log.Add(intent);
+            if (_log.Count > Capacity)
+            {
+                int remove = _log.Count - Capacity;
+                _log.RemoveRange(0, remove);
+            }
+        }
+    }
+}

--- a/Common/PositionSizer.cs
+++ b/Common/PositionSizer.cs
@@ -1,0 +1,65 @@
+using System;
+using NT8.SDK;
+
+namespace NT8.SDK.Common
+{
+    /// <summary>
+    /// Safety wrapper around an <see cref="ISizing"/> engine that clamps quantity into [MinQty, MaxQty]
+    /// and annotates the decision reason when a clamp occurs.
+    /// </summary>
+    public sealed class PositionSizer : ISizing
+    {
+        /// <summary>Inner sizing engine.</summary>
+        private readonly ISizing _inner;
+
+        /// <summary>Minimum allowed quantity (inclusive).</summary>
+        public int MinQty { get; private set; }
+
+        /// <summary>Maximum allowed quantity (inclusive). Use <c>int.MaxValue</c> for no upper bound.</summary>
+        public int MaxQty { get; private set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PositionSizer"/> class.
+        /// </summary>
+        /// <param name="inner">Inner sizing engine to wrap.</param>
+        /// <param name="minQty">Minimum allowed quantity (inclusive).</param>
+        /// <param name="maxQty">Maximum allowed quantity (inclusive). Use int.MaxValue for "no cap".</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="inner"/> is null.</exception>
+        public PositionSizer(ISizing inner, int minQty = 0, int maxQty = int.MaxValue)
+        {
+            if (inner == null) throw new ArgumentNullException("inner");
+            if (minQty < 0) minQty = 0;
+            if (maxQty < minQty) maxQty = minQty;
+            _inner = inner;
+            MinQty = minQty;
+            MaxQty = maxQty;
+        }
+
+        /// <inheritdoc/>
+        public SizeDecision Decide(RiskMode mode, PositionIntent intent)
+        {
+            SizeDecision d = _inner.Decide(mode, intent);
+            int q = d.Quantity;
+            string reason = d.Reason ?? string.Empty;
+
+            if (q < MinQty)
+            {
+                reason = Append(reason, "ClampedMin");
+                q = MinQty;
+            }
+            if (q > MaxQty)
+            {
+                reason = Append(reason, "ClampedMax");
+                q = MaxQty;
+            }
+
+            return new SizeDecision(q, reason, d.RiskModeUsed);
+        }
+
+        private static string Append(string baseReason, string tag)
+        {
+            if (string.IsNullOrEmpty(baseReason)) return tag;
+            return baseReason + "+" + tag;
+        }
+    }
+}

--- a/Common/TrailProfiles.cs
+++ b/Common/TrailProfiles.cs
@@ -1,0 +1,46 @@
+using System;
+using NT8.SDK;
+using NT8.SDK.Trailing;
+
+namespace NT8.SDK.Common
+{
+    /// <summary>
+    /// Factory for creating non-loosening trailing engines from <see cref="TrailingProfile"/> definitions.
+    /// Uses Step-5 ITrailingStop strategies and wraps them with the Step-6 non-loosening adapter.
+    /// </summary>
+    public sealed class TrailProfiles
+    {
+        /// <summary>
+        /// Creates an <see cref="ITrailing"/> engine that enforces non-loosening semantics.
+        /// Only <see cref="TrailingProfileType.FixedTicks"/> is active at this step.
+        /// Other profile types return a passthrough engine (returns prior stop).
+        /// </summary>
+        /// <param name="profile">Trailing profile DTO.</param>
+        /// <param name="tickSize">Instrument tick size (e.g., 0.25 for ES).</param>
+        /// <returns>Non-loosening trailing engine.</returns>
+        public static ITrailing Create(TrailingProfile profile, decimal tickSize)
+        {
+            if (profile.Type == TrailingProfileType.FixedTicks)
+            {
+                int ticks = (int)profile.Param1;
+                double ts = (double)tickSize;
+                ITrailingStop stop = new FixedTicksTrailingStop(ticks, ts);
+                return new TrailingAdapter(stop);
+            }
+
+            return new PassthroughTrailing();
+        }
+
+        /// <summary>
+        /// Passthrough trailing (identity) — returns the prior stop unchanged.
+        /// </summary>
+        private sealed class PassthroughTrailing : ITrailing
+        {
+            /// <inheritdoc/>
+            public decimal ComputeStop(decimal entry, decimal current, bool isLong, TrailingProfile profile, decimal priorStop)
+            {
+                return priorStop;
+            }
+        }
+    }
+}

--- a/Risk/BaseRisk.cs
+++ b/Risk/BaseRisk.cs
@@ -32,9 +32,10 @@ namespace NT8.SDK.Risk
     }
 
 #if DEBUG
-    internal sealed class FakeRiskAllow : BaseRisk
+    // Renamed to avoid collisions with other files.
+    internal sealed class DbgFakeRiskAllowBase : BaseRisk
     {
-        public FakeRiskAllow() : base(RiskMode.DCP) { }
+        public DbgFakeRiskAllowBase() : base(RiskMode.DCP) { }
         public override string EvaluateEntry(PositionIntent intent) { return string.Empty; }
     }
 
@@ -42,7 +43,7 @@ namespace NT8.SDK.Risk
     {
         internal static void Main()
         {
-            var risk = new FakeRiskAllow();
+            var risk = new DbgFakeRiskAllowBase();
             Console.WriteLine("Mode: " + risk.Mode);
             Console.WriteLine("CanTrade: " + risk.CanTradeNow());
             Console.WriteLine("EvaluateEntry: '" + risk.EvaluateEntry(new PositionIntent("ES", PositionSide.Long)) + "'");

--- a/Risk/CompositeRisk.cs
+++ b/Risk/CompositeRisk.cs
@@ -69,7 +69,8 @@ namespace NT8.SDK.Risk
     }
 
 #if DEBUG
-    internal sealed class FakeRiskAllow : IRisk
+    // Renamed to avoid collisions with other files.
+    internal sealed class DbgFakeRiskAllowComposite : IRisk
     {
         public RiskMode Mode { get { return RiskMode.DCP; } }
         public RiskLockoutState Lockout() { return RiskLockoutState.None; }
@@ -111,13 +112,13 @@ namespace NT8.SDK.Risk
     {
         internal static void Main()
         {
-            var composite = new CompositeRisk(new IRisk[] { new FakeRiskAllow(), new FakeRiskBlock("RULE_X") }, RiskMode.DCP);
+            var composite = new CompositeRisk(new IRisk[] { new DbgFakeRiskAllowComposite(), new FakeRiskBlock("RULE_X") }, RiskMode.DCP);
             Console.WriteLine("Entry decision: '" + composite.EvaluateEntry(new PositionIntent("ES", PositionSide.Long)) + "'");
 
-            var cooling = new CompositeRisk(new IRisk[] { new FakeRiskAllow(), new FakeRiskCooling() }, RiskMode.DCP);
+            var cooling = new CompositeRisk(new IRisk[] { new DbgFakeRiskAllowComposite(), new FakeRiskCooling() }, RiskMode.DCP);
             Console.WriteLine("Lockout state (cooling): " + cooling.Lockout());
 
-            var locked = new CompositeRisk(new IRisk[] { new FakeRiskAllow(), new FakeRiskCooling(), new FakeRiskLocked() }, RiskMode.DCP);
+            var locked = new CompositeRisk(new IRisk[] { new DbgFakeRiskAllowComposite(), new FakeRiskCooling(), new FakeRiskLocked() }, RiskMode.DCP);
             Console.WriteLine("Lockout state (locked): " + locked.Lockout());
         }
     }


### PR DESCRIPTION
## Summary
- map TrailingProfile DTOs to fixed-tick engines through the non-loosening adapter
- clamp sizing decisions to configured bounds while tagging clamp reasons
- add an in-memory order router that generates synthetic IDs and keeps a bounded log
- rename debug helper classes in risk files to avoid duplicate definitions

## Testing
- `dotnet build temp.csproj`

------
https://chatgpt.com/codex/tasks/task_e_689d121e17348329854491ee69103553