### PR TITLE
Step 11 — DiagnosticsSwitch + TradeLogger

### DIFF
--- a/Common/DiagnosticsSwitch.cs
+++ b/Common/DiagnosticsSwitch.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using NT8.SDK;
+
+namespace NT8.SDK.Common
+{
+    /// <summary>
+    /// Central toggle and allowlist filter for diagnostics and telemetry emission.
+    /// </summary>
+    public sealed class DiagnosticsSwitch
+    {
+        private readonly HashSet<string> _tagAllow = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        private readonly HashSet<string> _catAllow = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        private bool _useTagAllow;
+        private bool _useCatAllow;
+
+        /// <summary>
+        /// Gets or sets whether diagnostics and telemetry are globally enabled.
+        /// </summary>
+        public bool Enabled { get; set; } = true;
+
+        /// <summary>
+        /// Sets the allowlist of diagnostic tags. Null or empty clears the allowlist.
+        /// </summary>
+        /// <param name="tags">Tags allowed for capture.</param>
+        public void SetDiagnosticTagAllowlist(string[] tags)
+        {
+            _tagAllow.Clear();
+            if (tags == null || tags.Length == 0)
+            {
+                _useTagAllow = false;
+                return;
+            }
+            _useTagAllow = true;
+            for (int i = 0; i < tags.Length; i++)
+            {
+                var t = tags[i];
+                if (!string.IsNullOrEmpty(t)) _tagAllow.Add(t);
+            }
+        }
+
+        /// <summary>
+        /// Sets the allowlist of telemetry categories. Null or empty clears the allowlist.
+        /// </summary>
+        /// <param name="categories">Categories allowed for emission.</param>
+        public void SetTelemetryCategoryAllowlist(string[] categories)
+        {
+            _catAllow.Clear();
+            if (categories == null || categories.Length == 0)
+            {
+                _useCatAllow = false;
+                return;
+            }
+            _useCatAllow = true;
+            for (int i = 0; i < categories.Length; i++)
+            {
+                var c = categories[i];
+                if (!string.IsNullOrEmpty(c)) _catAllow.Add(c);
+            }
+        }
+
+        /// <summary>
+        /// Determines whether diagnostics should be captured for the specified tag.
+        /// </summary>
+        /// <param name="tag">Diagnostic tag.</param>
+        /// <returns>True if enabled and the tag is allowed.</returns>
+        public bool ShouldCapture(string tag)
+        {
+            if (!Enabled) return false;
+            if (!_useTagAllow) return true;
+            return _tagAllow.Contains(tag ?? string.Empty);
+        }
+
+        /// <summary>
+        /// Determines whether telemetry should be emitted for the specified event.
+        /// </summary>
+        /// <param name="evt">Telemetry event.</param>
+        /// <returns>True if enabled and the event category is allowed.</returns>
+        public bool ShouldEmit(TelemetryEvent evt)
+        {
+            if (!Enabled) return false;
+            if (!_useCatAllow) return true;
+            return _catAllow.Contains(evt.Category ?? string.Empty);
+        }
+
+#if DEBUG
+        internal static class DiagnosticsSwitchTests
+        {
+            internal static void Smoke()
+            {
+                var sw = new DiagnosticsSwitch();
+                System.Diagnostics.Debug.Assert(sw.ShouldCapture("foo"));
+                sw.SetDiagnosticTagAllowlist(new string[] { "bar" });
+                System.Diagnostics.Debug.Assert(sw.ShouldCapture("bar"));
+                System.Diagnostics.Debug.Assert(!sw.ShouldCapture("foo"));
+                sw.SetTelemetryCategoryAllowlist(new string[] { "cat" });
+                System.Diagnostics.Debug.Assert(sw.ShouldEmit(new TelemetryEvent("cat", "", "", "")));
+                System.Diagnostics.Debug.Assert(!sw.ShouldEmit(new TelemetryEvent("dog", "", "", "")));
+            }
+        }
+#endif
+    }
+}
+

--- a/Common/TradeLogger.cs
+++ b/Common/TradeLogger.cs
@@ -1,0 +1,225 @@
+using System;
+using NT8.SDK;
+
+namespace NT8.SDK.Common
+{
+    /// <summary>
+    /// Bounded in-memory log for trade lifecycle events.
+    /// </summary>
+    public sealed class TradeLogger
+    {
+        /// <summary>
+        /// Describes a trade-related event.
+        /// </summary>
+        [Serializable]
+        public struct TradeEvent
+        {
+            /// <summary>Timestamp in ET.</summary>
+            public DateTime EtTimestamp;
+            /// <summary>Instrument symbol.</summary>
+            public string Symbol;
+            /// <summary>Event tag (Submit, Fill, etc.).</summary>
+            public string Event;
+            /// <summary>Additional detail text.</summary>
+            public string Detail;
+        }
+
+        private readonly TradeEvent[] _buffer;
+        private readonly object _lock = new object();
+        private int _next;
+        private int _count;
+
+        /// <summary>
+        /// Initializes a new logger with the specified capacity.
+        /// </summary>
+        /// <param name="capacity">Maximum number of events stored.</param>
+        public TradeLogger(int capacity = 1024)
+        {
+            if (capacity < 1) capacity = 1;
+            _buffer = new TradeEvent[capacity];
+            _next = 0;
+            _count = 0;
+        }
+
+        /// <summary>
+        /// Gets the maximum number of events stored in the log.
+        /// </summary>
+        public int Capacity { get { return _buffer.Length; } }
+
+        /// <summary>
+        /// Appends an event to the log.
+        /// </summary>
+        /// <param name="evt">Trade event to append.</param>
+        public void Append(TradeEvent evt)
+        {
+            evt.Symbol = evt.Symbol ?? string.Empty;
+            evt.Event = evt.Event ?? string.Empty;
+            evt.Detail = evt.Detail ?? string.Empty;
+            lock (_lock)
+            {
+                _buffer[_next] = evt;
+                _next = (_next + 1) % _buffer.Length;
+                if (_count < _buffer.Length) _count++;
+            }
+        }
+
+        /// <summary>
+        /// Records a submission of a new order intent.
+        /// </summary>
+        /// <param name="intent">Order intent.</param>
+        public void OnSubmit(OrderIntent intent)
+        {
+            var detail = string.Format("{0}|{1}|{2}|{3}|{4}",
+                intent.IsLong ? "Buy" : "Sell",
+                intent.Quantity,
+                intent.Price,
+                intent.Type,
+                intent.Signal ?? string.Empty);
+            var evt = new TradeEvent
+            {
+                EtTimestamp = DateTime.UtcNow,
+                Symbol = intent.Symbol ?? string.Empty,
+                Event = "Submit",
+                Detail = detail
+            };
+            Append(evt);
+        }
+
+        /// <summary>
+        /// Records a modification of existing orders.
+        /// </summary>
+        /// <param name="ids">Order identifiers.</param>
+        /// <param name="intent">New order intent values.</param>
+        public void OnModify(OrderIds ids, OrderIntent intent)
+        {
+            var detail = string.Format("{0}|{1}|{2}|{3}|{4}|{5}|{6}",
+                ids.EntryId ?? string.Empty,
+                ids.StopId ?? string.Empty,
+                ids.TargetId ?? string.Empty,
+                intent.IsLong ? "Buy" : "Sell",
+                intent.Quantity,
+                intent.Price,
+                intent.Type);
+            var evt = new TradeEvent
+            {
+                EtTimestamp = DateTime.UtcNow,
+                Symbol = intent.Symbol ?? string.Empty,
+                Event = "Modify",
+                Detail = detail
+            };
+            Append(evt);
+        }
+
+        /// <summary>
+        /// Records cancellation of existing orders.
+        /// </summary>
+        /// <param name="ids">Order identifiers.</param>
+        /// <param name="symbol">Instrument symbol.</param>
+        public void OnCancel(OrderIds ids, string symbol)
+        {
+            var detail = string.Format("{0}|{1}|{2}",
+                ids.EntryId ?? string.Empty,
+                ids.StopId ?? string.Empty,
+                ids.TargetId ?? string.Empty);
+            var evt = new TradeEvent
+            {
+                EtTimestamp = DateTime.UtcNow,
+                Symbol = symbol ?? string.Empty,
+                Event = "Cancel",
+                Detail = detail
+            };
+            Append(evt);
+        }
+
+        /// <summary>
+        /// Records a fill event.
+        /// </summary>
+        /// <param name="symbol">Instrument symbol.</param>
+        /// <param name="isBuy">True if a buy fill.</param>
+        /// <param name="quantity">Fill quantity.</param>
+        /// <param name="price">Fill price.</param>
+        public void OnFill(string symbol, bool isBuy, int quantity, decimal price)
+        {
+            var detail = string.Format("{0} {1} @ {2}", isBuy ? "Buy" : "Sell", quantity, price);
+            var evt = new TradeEvent
+            {
+                EtTimestamp = DateTime.UtcNow,
+                Symbol = symbol ?? string.Empty,
+                Event = "Fill",
+                Detail = detail
+            };
+            Append(evt);
+        }
+
+        /// <summary>
+        /// Records a stop being hit.
+        /// </summary>
+        /// <param name="symbol">Instrument symbol.</param>
+        /// <param name="price">Stop price.</param>
+        public void OnStop(string symbol, decimal price)
+        {
+            var evt = new TradeEvent
+            {
+                EtTimestamp = DateTime.UtcNow,
+                Symbol = symbol ?? string.Empty,
+                Event = "Stop",
+                Detail = price.ToString()
+            };
+            Append(evt);
+        }
+
+        /// <summary>
+        /// Records a target fill.
+        /// </summary>
+        /// <param name="symbol">Instrument symbol.</param>
+        /// <param name="price">Target price.</param>
+        public void OnTarget(string symbol, decimal price)
+        {
+            var evt = new TradeEvent
+            {
+                EtTimestamp = DateTime.UtcNow,
+                Symbol = symbol ?? string.Empty,
+                Event = "Target",
+                Detail = price.ToString()
+            };
+            Append(evt);
+        }
+
+        /// <summary>
+        /// Returns a chronological snapshot of the log contents.
+        /// </summary>
+        /// <returns>Array of events from oldest to newest.</returns>
+        public TradeEvent[] Snapshot()
+        {
+            lock (_lock)
+            {
+                var result = new TradeEvent[_count];
+                var idx = (_next - _count + _buffer.Length) % _buffer.Length;
+                for (int i = 0; i < _count; i++)
+                {
+                    result[i] = _buffer[idx];
+                    idx = (idx + 1) % _buffer.Length;
+                }
+                return result;
+            }
+        }
+
+#if DEBUG
+        internal static class TradeLoggerTests
+        {
+            internal static void Smoke()
+            {
+                var log = new TradeLogger(2);
+                log.Append(new TradeEvent { EtTimestamp = DateTime.UtcNow, Symbol = "ES", Event = "A", Detail = "" });
+                log.Append(new TradeEvent { EtTimestamp = DateTime.UtcNow, Symbol = "ES", Event = "B", Detail = "" });
+                log.Append(new TradeEvent { EtTimestamp = DateTime.UtcNow, Symbol = "ES", Event = "C", Detail = "" });
+                var snap = log.Snapshot();
+                System.Diagnostics.Debug.Assert(snap.Length == 2);
+                System.Diagnostics.Debug.Assert(snap[0].Event == "B");
+                System.Diagnostics.Debug.Assert(snap[1].Event == "C");
+            }
+        }
+#endif
+    }
+}
+


### PR DESCRIPTION
## Summary
- add toggleable DiagnosticsSwitch with allowlists for diagnostic tags and telemetry categories
- implement bounded TradeLogger for trade lifecycle events

## Testing
- `python tools/nt8_guard.py`
- `mcs -langversion:7.2 -target:library $(find . -name '*.cs' -not -path './tools/*') -r:/usr/lib/mono/4.5/System.Web.Extensions.dll -out:build.dll`


------
https://chatgpt.com/codex/tasks/task_e_689d1667645c8329b1741ae3680dc55a