### PR TITLE
Add strategy base and example strategies

### DIFF
--- a/Strategies/CrabelORBStrategy.cs
+++ b/Strategies/CrabelORBStrategy.cs
@@ -1,0 +1,191 @@
+using System;
+
+namespace NT8.SDK.Strategies
+{
+    /// <summary>
+    /// Crabel-style Opening Range Breakout strategy shell.
+    /// </summary>
+    public class CrabelORBStrategy : StrategyBase
+    {
+        private DateTime _sessionDate = DateTime.MinValue;
+        private DateTime _orEnd = DateTime.MinValue;
+        private decimal _orHigh;
+        private decimal _orLow;
+        private bool _orComplete;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CrabelORBStrategy"/> class.
+        /// </summary>
+        /// <param name="sdk">SDK facade.</param>
+        /// <param name="symbol">Symbol to operate on.</param>
+        public CrabelORBStrategy(ISdk sdk, string symbol)
+            : base(sdk, symbol)
+        {
+            UseSessionBlackout = true;
+        }
+
+        /// <summary>
+        /// Gets or sets the opening range duration in minutes.
+        /// </summary>
+        public int OpeningRangeMinutes { get; set; }
+
+        /// <summary>
+        /// Gets or sets the breakout offset in ticks.
+        /// </summary>
+        public decimal BreakoutOffsetTicks { get; set; }
+
+        /// <summary>
+        /// Gets or sets the tick size.
+        /// </summary>
+        public decimal TickSize { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether session blackout checks are used.
+        /// </summary>
+        public bool UseSessionBlackout { get; set; }
+
+        /// <inheritdoc/>
+        public override void OnBar(DateTime etNow, decimal open, decimal high, decimal low, decimal close)
+        {
+            if (UseSessionBlackout && Sdk.Session != null && Sdk.Session.IsBlackout(etNow, Symbol))
+                return;
+
+            if (OpeningRangeMinutes <= 0 || BreakoutOffsetTicks <= 0m || TickSize <= 0m)
+                return;
+
+            if (etNow.Date != _sessionDate)
+            {
+                _sessionDate = etNow.Date;
+                _orEnd = etNow.AddMinutes(OpeningRangeMinutes);
+                _orHigh = high;
+                _orLow = low;
+                _orComplete = false;
+                return;
+            }
+
+            if (!_orComplete)
+            {
+                if (etNow < _orEnd)
+                {
+                    if (high > _orHigh) _orHigh = high;
+                    if (low < _orLow) _orLow = low;
+                    return;
+                }
+                _orComplete = true;
+            }
+
+            decimal offset = BreakoutOffsetTicks * TickSize;
+            if (close > _orHigh + offset && CanEnter(PositionSide.Long))
+            {
+                SizeDecision size = DecideSize();
+                if (size.Quantity > 0)
+                {
+                    Submit(OrderIntentType.Market, true, size.Quantity, 0m, "ORB_LONG");
+                }
+            }
+            else if (close < _orLow - offset && CanEnter(PositionSide.Short))
+            {
+                SizeDecision size = DecideSize();
+                if (size.Quantity > 0)
+                {
+                    Submit(OrderIntentType.Market, false, size.Quantity, 0m, "ORB_SHORT");
+                }
+            }
+        }
+
+#if DEBUG
+        internal static class CrabelORBStrategyTest
+        {
+            private class StubSdk : ISdk
+            {
+                public StubSdk()
+                {
+                    Risk = new StubRisk();
+                    Sizing = new StubSizing();
+                    Orders = new StubOrders();
+                    Session = new StubSession();
+                    Telemetry = new StubTelemetry();
+                    Diagnostics = new StubDiagnostics();
+                    Backtest = new StubBacktest();
+                }
+
+                public IRisk Risk { get; private set; }
+                public ISizing Sizing { get; private set; }
+                public IOrders Orders { get; private set; }
+                public ISession Session { get; private set; }
+                public ITrailing Trailing { get { return null; } }
+                public ITelemetry Telemetry { get; private set; }
+                public IDiagnostics Diagnostics { get; private set; }
+                public IBacktestHooks Backtest { get; private set; }
+
+                private class StubRisk : IRisk
+                {
+                    public RiskMode Mode { get { return RiskMode.DCP; } }
+                    public RiskLockoutState Lockout() { return RiskLockoutState.None; }
+                    public bool CanTradeNow() { return true; }
+                    public string EvaluateEntry(PositionIntent intent) { return string.Empty; }
+                    public void RecordWinLoss(bool win) { }
+                }
+
+                private class StubSizing : ISizing
+                {
+                    public SizeDecision Decide(RiskMode mode, PositionIntent intent)
+                    {
+                        return new SizeDecision(1, string.Empty, mode);
+                    }
+                }
+
+                private class StubOrders : IOrders
+                {
+                    public OrderIds Submit(OrderIntent intent)
+                    {
+                        return new OrderIds("E", "S", "T");
+                    }
+                    public bool Cancel(OrderIds ids) { return true; }
+                    public bool Modify(OrderIds ids, OrderIntent intent) { return true; }
+                }
+
+                private class StubSession : ISession
+                {
+                    public bool IsBlackout(DateTime etNow, string symbol) { return false; }
+                    public bool IsSettlementWindow(DateTime etNow, string symbol) { return false; }
+                    public DateTime SessionOpen(SessionKey key) { return DateTime.MinValue; }
+                    public DateTime SessionClose(SessionKey key) { return DateTime.MaxValue; }
+                }
+
+                private class StubTelemetry : ITelemetry
+                {
+                    public void Emit(TelemetryEvent evt) { }
+                }
+
+                private class StubDiagnostics : IDiagnostics
+                {
+                    public bool Enabled { get; set; }
+                    public void Capture(object snapshot, string tag) { }
+                }
+
+                private class StubBacktest : IBacktestHooks
+                {
+                    public void Stamp(string key, string value) { }
+                }
+            }
+
+            public static void Run()
+            {
+                var sdk = new StubSdk();
+                var strat = new CrabelORBStrategy(sdk, "ES")
+                {
+                    OpeningRangeMinutes = 1,
+                    BreakoutOffsetTicks = 1m,
+                    TickSize = 0.25m,
+                    UseSessionBlackout = false
+                };
+                DateTime start = new DateTime(2020, 1, 1, 9, 30, 0);
+                strat.OnBar(start, 100m, 101m, 99m, 100.5m);
+                strat.OnBar(start.AddMinutes(1), 100.5m, 101.5m, 100m, 101.6m);
+            }
+        }
+#endif
+    }
+}
+

--- a/Strategies/StrategyBase.cs
+++ b/Strategies/StrategyBase.cs
@@ -1,0 +1,142 @@
+using System;
+
+namespace NT8.SDK.Strategies
+{
+    /// <summary>
+    /// Base strategy providing minimal wiring helpers around the SDK services.
+    /// </summary>
+    public abstract class StrategyBase
+    {
+        private PositionSide _lastSide = PositionSide.Flat;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StrategyBase"/> class.
+        /// </summary>
+        /// <param name="sdk">SDK facade (may have null subsystems during early wiring).</param>
+        /// <param name="symbol">Symbol to operate on.</param>
+        protected StrategyBase(ISdk sdk, string symbol)
+        {
+            Sdk = sdk;
+            Symbol = symbol;
+        }
+
+        /// <summary>Gets the SDK facade.</summary>
+        public ISdk Sdk { get; private set; }
+
+        /// <summary>Gets the symbol this strategy operates on.</summary>
+        public string Symbol { get; private set; }
+
+        /// <summary>
+        /// Called before a bar is processed.
+        /// </summary>
+        /// <param name="etNow">Current eastern time.</param>
+        /// <param name="last">Last trade price.</param>
+        public virtual void OnBeforeBar(DateTime etNow, decimal last)
+        {
+        }
+
+        /// <summary>
+        /// Called when a bar closes.
+        /// </summary>
+        /// <param name="etNow">Current eastern time.</param>
+        /// <param name="open">Open price.</param>
+        /// <param name="high">High price.</param>
+        /// <param name="low">Low price.</param>
+        /// <param name="close">Close price.</param>
+        public virtual void OnBar(DateTime etNow, decimal open, decimal high, decimal low, decimal close)
+        {
+        }
+
+        /// <summary>
+        /// Called after a bar is processed.
+        /// </summary>
+        /// <param name="etNow">Current eastern time.</param>
+        public virtual void OnAfterBar(DateTime etNow)
+        {
+        }
+
+        /// <summary>
+        /// Determines whether a position can be entered. If <see cref="ISdk.Risk"/> is null,
+        /// this method allows entries (useful while wiring up components).
+        /// </summary>
+        /// <param name="side">Desired position side.</param>
+        /// <returns><c>true</c> if entry is allowed; otherwise, <c>false</c>.</returns>
+        protected bool CanEnter(PositionSide side)
+        {
+            _lastSide = side;
+
+            // If no risk engine is wired yet, allow by default.
+            if (Sdk == null || Sdk.Risk == null)
+                return true;
+
+            if (!Sdk.Risk.CanTradeNow())
+                return false;
+
+            // IRisk contract: empty string ("") means accepted.
+            string reason = Sdk.Risk.EvaluateEntry(new PositionIntent(Symbol, side));
+            return reason == string.Empty;
+        }
+
+        /// <summary>
+        /// Decides position size using the last evaluated side. If <see cref="ISdk.Sizing"/> is null,
+        /// this returns a conservative default size of 1 with reason "DefaultSize".
+        /// </summary>
+        /// <returns>Size decision.</returns>
+        protected SizeDecision DecideSize()
+        {
+            RiskMode mode = (Sdk != null && Sdk.Risk != null) ? Sdk.Risk.Mode : RiskMode.DCP;
+
+            if (Sdk != null && Sdk.Sizing != null)
+                return Sdk.Sizing.Decide(mode, new PositionIntent(Symbol, _lastSide));
+
+            return new SizeDecision(1, "DefaultSize", mode);
+        }
+
+        /// <summary>
+        /// Submits an order intent. If <see cref="ISdk.Orders"/> is null, returns empty IDs without throwing.
+        /// </summary>
+        /// <param name="type">Order type.</param>
+        /// <param name="isLong">True for long orders.</param>
+        /// <param name="qty">Quantity to submit.</param>
+        /// <param name="price">Price level (0 for market).</param>
+        /// <param name="signal">Signal name.</param>
+        /// <param name="ocoGroup">OCO group identifier.</param>
+        /// <returns>Identifiers for resulting orders, or empty identifiers if orders are not wired.</returns>
+        protected OrderIds Submit(OrderIntentType type, bool isLong, int qty, decimal price, string signal, string ocoGroup = null)
+        {
+            if (Sdk == null || Sdk.Orders == null)
+                return new OrderIds(string.Empty, string.Empty, string.Empty);
+
+            return Sdk.Orders.Submit(new OrderIntent(Symbol, isLong, qty, type, price, signal, ocoGroup));
+        }
+
+        /// <summary>
+        /// Captures a diagnostics message if the diagnostics sink is present and enabled.
+        /// </summary>
+        /// <param name="tag">Tag for the entry.</param>
+        /// <param name="message">Message to capture.</param>
+        protected void LogDiag(string tag, string message)
+        {
+            if (Sdk != null && Sdk.Diagnostics != null && Sdk.Diagnostics.Enabled)
+            {
+                Sdk.Diagnostics.Capture(new DiagnosticsEvent(tag ?? string.Empty, message ?? string.Empty), tag ?? string.Empty);
+            }
+        }
+
+        /// <summary>
+        /// Emits a telemetry event if a telemetry sink is present.
+        /// </summary>
+        /// <param name="category">Telemetry category.</param>
+        /// <param name="action">Telemetry action.</param>
+        /// <param name="label">Telemetry label.</param>
+        /// <param name="value">Telemetry value.</param>
+        protected void EmitTel(string category, string action, string label, string value)
+        {
+            if (Sdk != null && Sdk.Telemetry != null)
+            {
+                Sdk.Telemetry.Emit(new TelemetryEvent(category ?? string.Empty, action ?? string.Empty, label ?? string.Empty, value ?? string.Empty));
+            }
+        }
+    }
+}
+

--- a/Strategies/TemplateStrategy.cs
+++ b/Strategies/TemplateStrategy.cs
@@ -1,0 +1,39 @@
+using System;
+
+namespace NT8.SDK.Strategies
+{
+    /// <summary>
+    /// Simple example strategy demonstrating SDK wiring; attempts long entries on bullish bars.
+    /// </summary>
+    public class TemplateStrategy : StrategyBase
+    {
+        private int _bars;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TemplateStrategy"/> class.
+        /// </summary>
+        /// <param name="sdk">SDK facade.</param>
+        /// <param name="symbol">Symbol to operate on.</param>
+        public TemplateStrategy(ISdk sdk, string symbol)
+            : base(sdk, symbol)
+        {
+        }
+
+        /// <inheritdoc/>
+        public override void OnBar(DateTime etNow, decimal open, decimal high, decimal low, decimal close)
+        {
+            _bars++;
+            if (Sdk.Session != null && Sdk.Session.IsBlackout(etNow, Symbol))
+                return;
+            if (close > open && CanEnter(PositionSide.Long))
+            {
+                SizeDecision size = DecideSize();
+                if (size.Quantity > 0)
+                {
+                    Submit(OrderIntentType.Market, true, size.Quantity, 0m, "TPL_LONG");
+                }
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add StrategyBase with risk, sizing, order, telemetry helpers
- implement TemplateStrategy showing basic long-entry wiring
- implement CrabelORBStrategy with opening-range breakout logic and debug stub
- harden StrategyBase to tolerate missing risk/sizing/order subsystems

## Testing
- `mcs -target:library Abstractions/*.cs Strategies/*.cs -out:/tmp/nt8.strategies.dll`


------
https://chatgpt.com/codex/tasks/task_e_689d183826e083299d15745803c9ed57