### PR TITLE
feat: add tier-based PositionSizer factory

### DIFF
--- a/Common/PositionSizer.cs
+++ b/Common/PositionSizer.cs
@@ -9,7 +9,7 @@ namespace NT8.SDK.Common
     /// </summary>
     public sealed class PositionSizer : ISizing
     {
-        /// <summary>Inner sizing engine.</summary>
+        // Inner sizing engine
         private readonly ISizing _inner;
 
         /// <summary>Minimum allowed quantity (inclusive).</summary>
@@ -18,21 +18,55 @@ namespace NT8.SDK.Common
         /// <summary>Maximum allowed quantity (inclusive). Use <c>int.MaxValue</c> for no upper bound.</summary>
         public int MaxQty { get; private set; }
 
+        // Optional tier tag used to annotate clamp reason (e.g., the risk tier name)
+        private readonly string _tierTag;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="PositionSizer"/> class.
         /// </summary>
         /// <param name="inner">Inner sizing engine to wrap.</param>
         /// <param name="minQty">Minimum allowed quantity (inclusive).</param>
         /// <param name="maxQty">Maximum allowed quantity (inclusive). Use int.MaxValue for "no cap".</param>
+        /// <param name="clampTag">Optional tag appended to the reason when a clamp occurs.</param>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="inner"/> is null.</exception>
-        public PositionSizer(ISizing inner, int minQty = 0, int maxQty = int.MaxValue)
+        public PositionSizer(ISizing inner, int minQty = 0, int maxQty = int.MaxValue, string clampTag = null)
         {
             if (inner == null) throw new ArgumentNullException("inner");
             if (minQty < 0) minQty = 0;
             if (maxQty < minQty) maxQty = minQty;
+
             _inner = inner;
             MinQty = minQty;
             MaxQty = maxQty;
+            _tierTag = clampTag ?? string.Empty;
+        }
+
+        /// <summary>
+        /// Creates a <see cref="PositionSizer"/> that clamps using tier bounds for the supplied <paramref name="mode"/>.
+        /// </summary>
+        /// <param name="inner">Inner sizing engine.</param>
+        /// <param name="tiers">Tier set (min/max) per risk mode.</param>
+        /// <param name="mode">Risk mode to pick a tier from.</param>
+        /// <returns>Wrapped sizing that enforces the tier limits.</returns>
+        /// <remarks>
+        /// If <paramref name="tiers"/> is null, returns a wrapper with no additional clamping (0..int.MaxValue).
+        /// The tier's Tag (if any) is appended to the reason when a clamp occurs.
+        /// </remarks>
+        public static PositionSizer FromTiers(ISizing inner, RiskTiers tiers, RiskMode mode)
+        {
+            int min = 0;
+            int max = int.MaxValue;
+            string tag = string.Empty;
+
+            if (tiers != null)
+            {
+                RiskTiers.Tier t = tiers.For(mode);
+                min = t.Min;
+                max = t.Max;
+                tag = t.Tag;
+            }
+
+            return new PositionSizer(inner, min, max, tag);
         }
 
         /// <inheritdoc/>
@@ -45,11 +79,13 @@ namespace NT8.SDK.Common
             if (q < MinQty)
             {
                 reason = Append(reason, "ClampedMin");
+                if (_tierTag.Length != 0) reason = Append(reason, _tierTag);
                 q = MinQty;
             }
             if (q > MaxQty)
             {
                 reason = Append(reason, "ClampedMax");
+                if (_tierTag.Length != 0) reason = Append(reason, _tierTag);
                 q = MaxQty;
             }
 
@@ -63,3 +99,4 @@ namespace NT8.SDK.Common
         }
     }
 }
+


### PR DESCRIPTION
## Summary
- extend PositionSizer with optional clamp tag
- add PositionSizer.FromTiers to clamp by risk tier
- include tier tag in decision reason when clamped

## Testing
- `dotnet build` *(fails: command not found)*
- `mcs Abstractions/Dto.cs Abstractions/ISizing.cs Common/RiskTiers.cs Common/PositionSizer.cs -target:library -out:/tmp/sdk.dll`


------
https://chatgpt.com/codex/tasks/task_e_689d232fa2008329886bcb0d34a41ced