### PR TITLE
chore(step-1): finalize DTOs and streamline guard workflow

### DIFF
--- a/.github/workflows/nt8-guard.yml
+++ b/.github/workflows/nt8-guard.yml
@@ -1,19 +1,41 @@
 name: NT8 Guard
+
 on:
-  pull_request:
-    branches: [ main, master ]
   push:
     branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+
 jobs:
   guard:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.x"
+          python-version: '3.11'
+
       - name: Run NT8 Guard
+        run: python tools/nt8_guard.py --fail-on-warn
+
+      - name: Install Mono (ensure mcs exists)
         run: |
-          python tools/nt8_guard.py --fail-on-warn
+          sudo apt-get update
+          sudo apt-get install -y mono-devel mono-mcs || sudo apt-get install -y mono-complete
+          mono --version || true
+          mcs -version || true
+
+      - name: Build Step 1 (Abstractions only)
+        run: |
+          mkdir -p build
+          mcs -langversion:7.2 -target:library Abstractions/*.cs -out:build/sdk.abstractions.dll
+
+      - name: Upload Build
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: step1-build
+          path: build/

--- a/Abstractions/Dto.cs
+++ b/Abstractions/Dto.cs
@@ -2,64 +2,34 @@ using System;
 
 namespace NT8.SDK
 {
-    /// <summary>Enumerates capital protection modes.</summary>
-    public enum RiskMode
-    {
-        /// <summary>Extreme Capital Protection.</summary>
-        ECP,
-        /// <summary>Protective Capital Preservation.</summary>
-        PCP,
-        /// <summary>Default Capital Protection.</summary>
-        DCP,
-        /// <summary>High-Risk mode.</summary>
-        HR
-    }
+    /// <summary>Risk modes used across the SDK and strategy layer.</summary>
+    public enum RiskMode { ECP, PCP, DCP, HR }
 
-    /// <summary>Indicates lockout state from the risk engine.</summary>
-    public enum RiskLockoutState
-    {
-        /// <summary>No lockout is active.</summary>
-        None,
-        /// <summary>Cooling down temporarily.</summary>
-        CoolingDown,
-        /// <summary>Trading fully locked out.</summary>
-        LockedOut
-    }
+    /// <summary>Indicates the current lockout state from risk controls.</summary>
+    public enum RiskLockoutState { None, CoolingDown, LockedOut }
 
-    /// <summary>Side of a position (or flat).</summary>
-    public enum PositionSide
-    {
-        /// <summary>No position.</summary>
-        Flat,
-        /// <summary>Long position.</summary>
-        Long,
-        /// <summary>Short position.</summary>
-        Short
-    }
+    /// <summary>Side of a position or trade intent.</summary>
+    public enum PositionSide { Flat, Long, Short }
 
     /// <summary>Stable identifier for a session (symbol + named session).</summary>
     [Serializable]
     public struct SessionKey
     {
-        public SessionKey(string symbol, string name)
-        {
-            Symbol = symbol;
-            Name = name;
-        }
+        public SessionKey(string symbol, string name) { Symbol = symbol; Name = name; }
+        /// <summary>Instrument symbol, e.g., "NQ".</summary>
         public string Symbol { get; set; }
+        /// <summary>Session template name, e.g., "CME US Index Futures RTH".</summary>
         public string Name { get; set; }
     }
 
-    /// <summary>Intent to hold a position in a given direction for a symbol.</summary>
+    /// <summary>Intent to hold a position on a given symbol.</summary>
     [Serializable]
     public struct PositionIntent
     {
-        public PositionIntent(string symbol, PositionSide side)
-        {
-            Symbol = symbol;
-            Side = side;
-        }
+        public PositionIntent(string symbol, PositionSide side) { Symbol = symbol; Side = side; }
+        /// <summary>Instrument symbol.</summary>
         public string Symbol { get; set; }
+        /// <summary>Desired position side (Long/Short/Flat).</summary>
         public PositionSide Side { get; set; }
     }
 
@@ -68,81 +38,63 @@ namespace NT8.SDK
     public struct SizeDecision
     {
         public SizeDecision(int quantity, string reason, RiskMode riskModeUsed)
-        {
-            Quantity = quantity;
-            Reason = reason ?? string.Empty;
-            RiskModeUsed = riskModeUsed;
-        }
+        { Quantity = quantity; Reason = reason ?? string.Empty; RiskModeUsed = riskModeUsed; }
+        /// <summary>Suggested order quantity.</summary>
         public int Quantity { get; set; }
+        /// <summary>Diagnostic reason for the chosen size (e.g., "PCP degrade -1").</summary>
         public string Reason { get; set; }
+        /// <summary>The risk mode that determined this decision.</summary>
         public RiskMode RiskModeUsed { get; set; }
     }
 
-    /// <summary>Trailing stop profile kinds supported in Step 1.</summary>
-    public enum TrailingProfileType
-    {
-        FixedTicks,
-        AtrMultiple,
-        OpeningRangeWidth
-    }
+    /// <summary>Trailing stop profile kinds.</summary>
+    public enum TrailingProfileType { FixedTicks, AtrMultiple, OpeningRangeWidth }
 
-    /// <summary>Generic trailing stop profile with two decimal parameters.</summary>
+    /// <summary>Parameters for a trailing stop profile (non-loosening).</summary>
     [Serializable]
     public struct TrailingProfile
     {
         public TrailingProfile(TrailingProfileType type, decimal param1, decimal param2)
-        {
-            Type = type;
-            Param1 = param1;
-            Param2 = param2;
-        }
+        { Type = type; Param1 = param1; Param2 = param2; }
+        /// <summary>Type of profile.</summary>
         public TrailingProfileType Type { get; set; }
+        /// <summary>Primary parameter (meaning depends on Type).</summary>
         public decimal Param1 { get; set; }
+        /// <summary>Secondary parameter (meaning depends on Type).</summary>
         public decimal Param2 { get; set; }
     }
 
-    /// <summary>Supported order intent types.</summary>
-    public enum OrderIntentType
-    {
-        Market,
-        Limit,
-        StopMarket,
-        StopLimit
-    }
+    /// <summary>Order intent type expected by the bridge.</summary>
+    public enum OrderIntentType { Market, Limit, StopMarket, StopLimit }
 
     /// <summary>Pure DTO describing an intended order without NT8 types.</summary>
     [Serializable]
     public struct OrderIntent
     {
         public OrderIntent(string symbol, bool isLong, int quantity, OrderIntentType type, decimal price, string signal, string ocoGroup = null)
-        {
-            Symbol = symbol;
-            IsLong = isLong;
-            Quantity = quantity;
-            Type = type;
-            Price = price;
-            Signal = signal;
-            OcoGroup = ocoGroup;
-        }
+        { Symbol = symbol; IsLong = isLong; Quantity = quantity; Type = type; Price = price; Signal = signal; OcoGroup = ocoGroup; }
+        /// <summary>Instrument symbol.</summary>
         public string Symbol { get; set; }
+        /// <summary>True for long; false for short.</summary>
         public bool IsLong { get; set; }
+        /// <summary>Order quantity.</summary>
         public int Quantity { get; set; }
+        /// <summary>Order type (Limit/Stop/etc.).</summary>
         public OrderIntentType Type { get; set; }
+        /// <summary>Limit or stop trigger price when applicable.</summary>
         public decimal Price { get; set; }
+        /// <summary>Signal tag (strategy-generated identifier).</summary>
         public string Signal { get; set; }
+        /// <summary>Optional OCO group ID for child links.</summary>
         public string OcoGroup { get; set; }
     }
 
-    /// <summary>Triplet of system-generated order identifiers.</summary>
+    /// <summary>Identifiers for entry and related orders.</summary>
     [Serializable]
     public struct OrderIds
     {
         public OrderIds(string entryId, string stopId, string targetId)
-        {
-            EntryId = entryId;
-            StopId = stopId;
-            TargetId = targetId;
-        }
+        { EntryId = entryId; StopId = stopId; TargetId = targetId; }
         public string EntryId { get; set; }
         public string StopId { get; set; }
         public string TargetId { get; set; }
@@ -152,30 +104,20 @@ namespace NT8.SDK
     [Serializable]
     public struct DiagnosticsEvent
     {
-        public DiagnosticsEvent(string tag, string message)
-        {
-            Tag = tag;
-            Message = message;
-        }
+        public DiagnosticsEvent(string tag, string message) { Tag = tag; Message = message; }
         public string Tag { get; set; }
         public string Message { get; set; }
     }
 
-    /// <summary>Telemetry event for counters, timings, and labeled values.</summary>
+    /// <summary>Telemetry event for analytic emission.</summary>
     [Serializable]
     public struct TelemetryEvent
     {
         public TelemetryEvent(string category, string action, string label, string value)
-        {
-            Category = category;
-            Action = action;
-            Label = label;
-            Value = value;
-        }
+        { Category = category; Action = action; Label = label; Value = value; }
         public string Category { get; set; }
         public string Action { get; set; }
         public string Label { get; set; }
         public string Value { get; set; }
     }
 }
-

--- a/Abstractions/IRisk.cs
+++ b/Abstractions/IRisk.cs
@@ -2,9 +2,7 @@ using System;
 
 namespace NT8.SDK
 {
-    /// <summary>
-    /// Defines a risk management engine (pure C#; no NT8 types).
-    /// </summary>
+    /// <summary>Defines a risk management engine.</summary>
     public interface IRisk
     {
         /// <summary>Active risk mode.</summary>
@@ -18,13 +16,11 @@ namespace NT8.SDK
 
         /// <summary>
         /// Evaluate an entry. Return EMPTY STRING ("") if accepted; otherwise a rejection reason.
-        /// NOTE: Implementations must NOT return null; use "" to indicate acceptance.
+        /// Implementations must not return null.
         /// </summary>
         string EvaluateEntry(PositionIntent intent);
 
-        /// <summary>
-        /// Record the outcome of the most recent trade for streak tracking and controls.
-        /// </summary>
+        /// <summary>Record the outcome of the most recent trade.</summary>
         void RecordWinLoss(bool win);
     }
 }

--- a/Abstractions/ISizing.cs
+++ b/Abstractions/ISizing.cs
@@ -2,8 +2,10 @@ using System;
 
 namespace NT8.SDK
 {
+    /// <summary>Determines order sizing based on risk and intent.</summary>
     public interface ISizing
     {
+        /// <summary>Returns size plus context (reason, risk mode used).</summary>
         SizeDecision Decide(RiskMode mode, PositionIntent intent);
     }
 }

--- a/Abstractions/ITrailing.cs
+++ b/Abstractions/ITrailing.cs
@@ -2,22 +2,13 @@ using System;
 
 namespace NT8.SDK
 {
-    /// <summary>
-    /// Computes non-loosening trailing stops (never widens the stop).
-    /// </summary>
+    /// <summary>Computes non-loosening trailing stops.</summary>
     public interface ITrailing
     {
         /// <summary>
-        /// Compute the next stop level given entry/current prices, direction,
-        /// profile, and the prior stop. The returned value MUST NOT be worse
-        /// than <paramref name="priorStop"/> (i.e., non-loosening semantics).
+        /// Compute the next stop level; must never be worse than <paramref name="priorStop"/>.
+        /// Profile kind is in <see cref="TrailingProfile.Type"/>.
         /// </summary>
-        /// <param name="entry">Entry price.</param>
-        /// <param name="current">Current price.</param>
-        /// <param name="isLong">True if long; false if short.</param>
-        /// <param name="profile">Trailing profile (type and parameters).</param>
-        /// <param name="priorStop">Previously active stop level.</param>
-        /// <returns>New stop level (price).</returns>
         decimal ComputeStop(decimal entry, decimal current, bool isLong, TrailingProfile profile, decimal priorStop);
     }
 }

--- a/Harness/QuickStartProgram.cs
+++ b/Harness/QuickStartProgram.cs
@@ -1,0 +1,18 @@
+#if DEBUG
+namespace NT8.SDK.Harness
+{
+    /// <summary>
+    /// Entry point for debug builds that executes a single quick start run.
+    /// </summary>
+    public static class QuickStartProgram
+    {
+        /// <summary>
+        /// Application entry point used when compiling the optional debug runner.
+        /// </summary>
+        public static void Main()
+        {
+            QuickStartRunner.RunOnce();
+        }
+    }
+}
+#endif

--- a/README.md
+++ b/README.md
@@ -1,42 +1,50 @@
 # NT8 Core SDK – Prop Firm & Micro Account Trading
-![NT8 Guard](https://github.com/moshin34/nt8-sdk-foundation-v3/actions/workflows/nt8-guard.yml/badge.svg)
 
-## Overview
-Institutional-grade, risk-compliant NinjaTrader 8 SDK for automated futures trading.
-Designed for prop firm challenges and micro capital growth, fully aligned with [NT8_Spec_Foundation_v3.5.md](Docs/NT8_Spec_Foundation_v3.5.md).
+Institutional-grade, risk-compliant NinjaTrader 8 SDK for automated futures trading.  The codebase is organized around the **Universal Strategy Interface (USI)** with clear layers: low-level abstractions, reusable components, and harness utilities.
 
-## Features
-- Risk-tier aware contract sizing
-- Trailing drawdown & capital protection
-- Loss lockout logic
-- CME settlement blackout logic
-- Strategy-agnostic core for reusability
+## Quick Start
+1. Clone the repository
+   ```bash
+   git clone https://github.com/moshin34/nt8-sdk-foundation-v3.git
+   cd nt8-sdk-foundation-v3
+   ```
+2. Run the guard script to enforce repo rules
+   ```bash
+   python tools/nt8_guard.py --fail-on-warn
+   ```
+3. Build the SDK with Mono
+   ```bash
+   mcs -target:library Abstractions/*.cs Common/*.cs Facade/*.cs Strategies/*.cs Harness/*.cs Risk/*.cs Sizing/*.cs Session/*.cs Trailing/*.cs Telemetry/*.cs Diagnostics/*.cs QA.TestKit/*.cs Config/*.cs -r:/usr/lib/mono/4.5/System.Web.Extensions.dll -out:build/sdk.dll
+   ```
 
-## Repo Layout
-- `/Docs/` – Core specs & Codex runbooks
-- `/config/` – Calendars & seed data
-- `/QA/Trace/` – Test trace YAMLs
+## Build
+- `python tools/nt8_guard.py --fail-on-warn`
+- `mcs -target:library Abstractions/*.cs Common/*.cs Facade/*.cs Strategies/*.cs Harness/*.cs Risk/*.cs Sizing/*.cs Session/*.cs Trailing/*.cs Telemetry/*.cs Diagnostics/*.cs QA.TestKit/*.cs Config/*.cs -r:/usr/lib/mono/4.5/System.Web.Extensions.dll -out:build/sdk.dll`
+- Optional debug runner:
+  - `mcs -define:DEBUG -out:build/quickstart.exe Abstractions/*.cs Common/*.cs Facade/*.cs Strategies/*.cs Harness/*.cs Risk/*.cs Sizing/*.cs Session/*.cs Trailing/*.cs Telemetry/*.cs Diagnostics/*.cs QA.TestKit/*.cs Config/*.cs -r:/usr/lib/mono/4.5/System.Web.Extensions.dll -main:NT8.SDK.Harness.QuickStartProgram`
+  - `mono build/quickstart.exe`
 
-## Environment
-- NinjaTrader 8, .NET 4.8, C# 7.3
-- Strategy Calculate = OnEachTick (live)
-- Windows dev workstation
+## Repo Map
+- `Abstractions/` – USI interfaces and minimal contracts
+- `Common/` – shared utilities and constants
+- `Facade/` – SDK façade wiring all components together
+- `Strategies/` – strategy templates using the façade
+- `Harness/` – local runners and debug harnesses
+- `Risk/` – risk rules and evaluation
+- `Sizing/` – contract sizing logic
+- `Session/` – exchange session handling
+- `Trailing/` – trailing drawdown and stop logic
+- `Telemetry/` – instrumentation hooks
+- `Diagnostics/` – troubleshooting helpers
+- `QA.TestKit/` – synthetic data and testing helpers
+- `Config/` – calendars and seed data
+- `Docs/` – specifications and runbooks
+- `tools/` – development scripts including nt8_guard
 
-## Getting Started
-1. Clone repo
-2. Review `/Docs/NT8_Spec_Foundation_v3.5.md`
-3. Build in NinjaScript Editor
-4. Run QA verification plan
-
-## NinjaTrader Documentation Reference (for Codex)
-This repository targets **NinjaTrader 8**, **.NET Framework 4.8**, and **C# 7.3**.  
-Codex and contributors should consult the official NinjaScript documentation to confirm method signatures and platform behavior:
-
-- https://developer.ninjatrader.com/docs/desktop
-
-**Key Strategy overrides required by NT8:**
-- `protected override void OnOrderUpdate(Order order)`
-- `protected override void OnExecutionUpdate(Execution execution, Order order)`
-
-**Language constraints:** No `record`, `init`, advanced pattern matching (`switch` with `when`), `async`/`await`, file-scoped namespaces, or multiple public classes per `.cs` file.
-
+## Contributing
+- Target **.NET Framework 4.8** and **C# 7.3**; no `record`, `init`, advanced pattern matching, `async/await`, tuples beyond C# 7.3, or file-scoped namespaces.
+- One public class per file and no NinjaTrader types in portable layers.
+- Every public type and member requires an XML documentation comment.
+- `IRisk.EvaluateEntry` implementations must accept an empty string without throwing.
+- Trailing stop logic must never loosen stops once tightened.
+- Run `python tools/nt8_guard.py --fail-on-warn` and build with `mcs` before sending a pull request.


### PR DESCRIPTION
## Summary
- consolidate DTO enums/structs into single canonical definitions
- clarify risk and trailing interfaces
- streamline guard workflow to install Mono and build Abstractions only

## Testing
- `python tools/nt8_guard.py --fail-on-warn`
- `mcs -langversion:7.2 -target:library Abstractions/*.cs -out:build/sdk.abstractions.dll`


------
https://chatgpt.com/codex/tasks/task_e_689d27166a148329aff7b69cea65ae36