### PR TITLE
feat: wire SDK into NT8 (strategy + print-only Nt8Orders bridge)

### DIFF
--- a/NT8Orders.cs
+++ b/NT8Orders.cs
@@ -1,0 +1,38 @@
+// Minimal, print-only IOrders bridge for NinjaTrader.
+// Uses fully-qualified names to avoid any import issues.
+
+namespace NT8.SDK.NT8Bridge
+{
+    public sealed class Nt8Orders : NT8.SDK.IOrders
+    {
+        private readonly NinjaTrader.NinjaScript.Strategies.Strategy _host;
+
+        public Nt8Orders(NinjaTrader.NinjaScript.Strategies.Strategy host)
+        {
+            _host = host ?? throw new System.ArgumentNullException(nameof(host));
+        }
+
+        public NT8.SDK.OrderIds Submit(NT8.SDK.OrderIntent intent)
+        {
+            Print("[Nt8Orders] Submit called");
+            var stamp = System.DateTime.UtcNow.Ticks.ToString();
+            var baseId = "NT8-" + stamp;
+            return new NT8.SDK.OrderIds(baseId + "-E", baseId + "-S", baseId + "-T");
+        }
+
+        public void Cancel(NT8.SDK.OrderIds ids)
+        {
+            Print("[Nt8Orders] Cancel called");
+        }
+
+        public void Modify(NT8.SDK.OrderIds ids, NT8.SDK.OrderIntent intent)
+        {
+            Print("[Nt8Orders] Modify called");
+        }
+
+        private void Print(string message)
+        {
+            try { _host?.Print(message); } catch { /* ignore */ }
+        }
+    }
+}

--- a/SDK.csproj
+++ b/SDK.csproj
@@ -21,6 +21,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Debug\SDK.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -110,4 +111,9 @@
     <Compile Include="TrailProfiles.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>xcopy "$(TargetPath)" "%25USERPROFILE%25\Documents\NinjaTrader 8\bin\Custom\" /Y
+xcopy "$(TargetDir)$(TargetName).xml" "%25USERPROFILE%25\Documents\NinjaTrader 8\bin\Custom\" /Y
+</PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/SdkStrategyShell.cs
+++ b/SdkStrategyShell.cs
@@ -1,0 +1,39 @@
+#region Using declarations
+using System;
+using NinjaTrader.NinjaScript;
+#endregion
+
+// NOTE: This shell just proves the SDK DLL is wired up.
+// It uses the SDK's defaults except orders, which are routed via Nt8Orders.
+
+namespace NinjaTrader.NinjaScript.Strategies
+{
+    public class SdkStrategyShell : Strategy
+    {
+        private NT8.SDK.ISdk _sdk;
+
+        protected override void OnStateChange()
+        {
+            if (State == State.SetDefaults)
+            {
+                Name = "SdkStrategyShell";
+                Calculate = Calculate.OnBarClose;
+                IsInstantiatedOnEachOptimizationIteration = false;
+            }
+            else if (State == State.DataLoaded)
+            {
+                var orders = new NT8.SDK.NT8Bridge.Nt8Orders(this);
+                _sdk = new NT8.SDK.Facade.SdkBuilder()
+                    .WithOrders(orders)
+                    .Build();
+
+                Print("SDK wired with Nt8Orders (no-trade bridge)");
+            }
+        }
+
+        protected override void OnBarUpdate()
+        {
+            // no-op for now — add calls into your SDK when ready
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Describe what this PR adds/changes.

## Compile Target (must pass)
- [ ] NinjaTrader 8, .NET Framework 4.8, C# 7.3 only
- [ ] One public class per file
- [ ] No modern C# constructs (`record`, `init`, advanced `switch` patterns, `async`)

## NinjaTrader Signatures (if Strategy code)
- [ ] Uses exact overrides:
  - protected override void OnOrderUpdate(Order order)
  - protected override void OnExecutionUpdate(Execution execution, Order order)

## Layering & Hygiene
- [ ] Pure C# layers compile without NT8 refs
- [ ] Bridge has no indicators
- [ ] Template strategy compiles and runs on SIM

## Diagnostics/Logs
- [ ] Diagnostics path auto-created; no exceptions
- [ ] JSONL compact; no PII

## Testing
- [ ] Entry+OCO+trailing happy path
- [ ] Rejection → protective flatten

## Docs
- [ ] README updated if needed
