### PR TITLE
ci: baseline cleanup — pin labeler to v4 and keep safe auto-merge gate

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,4 +1,5 @@
-﻿name: Auto-merge (squash)
+﻿name: Auto-merge (squash, safe)
+
 on:
   pull_request:
     types: [labeled, synchronize, reopened, ready_for_review]
@@ -7,20 +8,46 @@ on:
   status: {}
 
 jobs:
-  automerge:
+  gate:
+    name: Path gate
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
+    outputs:
+      ok_to_merge: ${{ steps.decide.outputs.ok }}
     steps:
-      - name: Enable auto-merge when labeled
-        if: contains(github.event.pull_request.labels.*.name, 'auto-merge')
-        uses: peter-evans/enable-pull-request-automerge@v3
+      - uses: actions/checkout@v4
+      - id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            protected:
+              - "NT8Bridge/**"
+              - "Strategies/**"
+              - "Risk/**"
+              - "Session/**"
+              - "tools/**"
+              - ".github/**"
+      - id: decide
+        run: |
+          if [ "${{ steps.filter.outputs.protected }}" = "true" ]; then
+            echo "ok=false" >> $GITHUB_OUTPUT
+          else
+            echo "ok=true" >> $GITHUB_OUTPUT
+          fi
+
+  automerge:
+    needs: gate
+    if: >
+      github.event.pull_request.draft == false &&
+      contains(github.event.pull_request.labels.*.name, 'auto-merge') &&
+      needs.gate.outputs.ok_to_merge == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: peter-evans/enable-pull-request-automerge@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           pull-request-number: ${{ github.event.pull_request.number }}
           merge-method: squash
-      - name: Auto-merge when checks pass
-        if: contains(github.event.pull_request.labels.*.name, 'auto-merge')
-        uses: peter-evans/auto-merge@v3
+      - uses: peter-evans/auto-merge@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           merge-method: squash

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -6,6 +6,6 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@v4
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What changed?
-

## Why?
-

## How tested?
- [ ] Guard passed (`powershell .\tools\guard.ps1`)
- [ ] Build ok (`powershell .\tools\build.ps1`)
- [ ] Harness ok (`powershell .\tools\test.ps1`)
- [ ] NT8 compile ok (if NT8Bridge/Strategies touched)

## Risk / Rollback
-

## Screenshots / Logs
