### PR TITLE
Harden guard against QA folder variants and show SDK version on load

### DIFF
--- a/QA/Trace/readme.txt
+++ b/QA/Trace/readme.txt
@@ -1,1 +1,0 @@
-Empty YAML stubs for QA trace.

--- a/SdkStrategyShell.cs
+++ b/SdkStrategyShell.cs
@@ -27,6 +27,8 @@ namespace NinjaTrader.NinjaScript.Strategies
                     .WithOrders(orders)
                     .Build();
 
+                var version = typeof(NT8.SDK.Facade.SdkBuilder).Assembly.GetName().Version;
+                Print($"NT8 SDK v{version} loaded.");
                 Print("SDK wired with Nt8Orders (no-trade bridge)");
             }
         }

--- a/Strategies/SdkStrategyShell.cs
+++ b/Strategies/SdkStrategyShell.cs
@@ -81,6 +81,8 @@ namespace NinjaTrader.NinjaScript.Strategies
             else if (State == State.DataLoaded)
             {
                 _submitted = false;
+                var version = typeof(SdkBuilder).Assembly.GetName().Version;
+                Print($"NT8 SDK v{version} loaded.");
             }
         }
 

--- a/tools/guard.ps1
+++ b/tools/guard.ps1
@@ -4,10 +4,11 @@ $errors = @()
 
 # 1) Duplicate/colliding folders
 $pairs = @(
-  @{A='Docs';B='docs'},
-  @{A='Diagnostics';B='Diag'},
-  @{A='QA.TestKit';B='QA_Trace'},
-  @{A='NT8Bridge';B='Bridge'}
+  @{A='Docs';        B='docs'},
+  @{A='Diagnostics'; B='Diag'},
+  @{A='NT8Bridge';   B='Bridge'},
+  @{A='QA.TestKit';  B='QA/ Trace'},  # space variant
+  @{A='QA.TestKit';  B='QA_Trace'}    # underscore variant
 )
 foreach ($p in $pairs) {
   if ((Test-Path $p.A) -and (Test-Path $p.B)) {


### PR DESCRIPTION
## Summary
- remove stray QA/Trace folder
- guard against QA.TestKit colliding with QA/Trace or QA_Trace
- print SDK version when strategies load

## Testing
- `pwsh -NoLogo -NoProfile -File tools/guard.ps1` *(fails: command not found)*
- `pwsh -NoLogo -NoProfile -File tools/build.ps1` *(fails: command not found)*
- `pwsh -NoLogo -NoProfile -File tools/test.ps1` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689ea08aa6e48329bd8ddfbdcb0e3727