### PR TITLE
ci(guard): robust triggers for NT8 Guard

### DIFF
--- a/.github/workflows/nt8-guard.yml
+++ b/.github/workflows/nt8-guard.yml
@@ -1,13 +1,19 @@
 ﻿name: NT8 Guard (layout-aware)
-
 on:
-  pull_request:
-    branches: [ main ]
   push:
     branches: [ main ]
+    paths:
+      - '**/*.cs'
+      - '.github/workflows/nt8-guard.yml'
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [ main ]
+    paths:
+      - '**/*.cs'
+      - '.github/workflows/nt8-guard.yml'
+  workflow_dispatch:
 
-jobs:
-  guard:
+jobs:guard:
     runs-on: ubuntu-latest
     container: mono:6.12
     steps:


### PR DESCRIPTION
Adds push(main), pull_request, and workflow_dispatch triggers; dispatching a run on this branch to verify.