### PR TITLE
feat(nt8bridge): print latest tick every 5s (no orders)

### DIFF
--- a/NT8Bridge/SdkStrategyBridge.cs
+++ b/NT8Bridge/SdkStrategyBridge.cs
@@ -7,26 +7,28 @@ using NT8.SDK.Abstractions;             // ISdk
 namespace NinjaTrader.NinjaScript.Strategies
 {
     /// <summary>
-    /// SdkStrategyBridge: Minimal bridge that proves end-to-end wiring.
-    /// - On DataLoaded: instantiate SDK and print the startup banner.
-    /// - On each tick/bar update: forward time/price to SDK (no orders).
+    /// SdkStrategyBridge
+    /// - On load: instantiate SDK and print startup banner.
+    /// - On each tick: forward time/price to SDK (no orders).
+    /// - Every 5 seconds (chart time): print the latest SDK tick for visibility.
     /// </summary>
     public class SdkStrategyBridge : Strategy
     {
         private ISdk _sdk;
+        private DateTime _lastPrint = DateTime.MinValue;
+        private readonly TimeSpan _printEvery = TimeSpan.FromSeconds(5);
 
         protected override void OnStateChange()
         {
             if (State == State.SetDefaults)
             {
                 Name = "SdkStrategyBridge";
-                Calculate = Calculate.OnEachTick; // tick-level updates
-                IsUnmanaged = false;              // no orders here
+                Calculate = Calculate.OnEachTick;   // tick-level updates
+                IsUnmanaged = false;                // no orders here
                 IsInstantiatedOnEachOptimizationIteration = false;
             }
             else if (State == State.DataLoaded)
             {
-                // Create SDK façade and print banner
                 _sdk = new SdkFacade();
                 Print(_sdk.StartupBanner);
             }
@@ -38,10 +40,25 @@ namespace NinjaTrader.NinjaScript.Strategies
                 return;
 
             // Forward the latest bar's time/price into the SDK (no orders).
-            // Using Strategy's Time and Close series to avoid NT market-data specifics.
             DateTime t = Time[0];
             double price = Close[0];
             _sdk.OnPriceTick(t, price);
+
+            // Every 5 seconds of chart time, print latest SDK tick if available.
+            if (_lastPrint == DateTime.MinValue || (t - _lastPrint) >= _printEvery)
+            {
+                DateTime lt;
+                double lp;
+                if (_sdk.TryGetLatestTick(out lt, out lp))
+                {
+                    Print("[SDK] latest tick: " + lt.ToString("o") + "  price=" + lp);
+                }
+                else
+                {
+                    Print("[SDK] no ticks yet");
+                }
+                _lastPrint = t;
+            }
         }
     }
 }


### PR DESCRIPTION
Bridge strategy now prints the latest SDK tick every 5 seconds for live visibility. Guard-safe (NT8Bridge not part of Guard compile).