### PR TITLE
feat(nt8bridge): print latest tick + bias transitions (no orders)

### DIFF
--- a/NT8Bridge/SdkStrategyBridge.cs
+++ b/NT8Bridge/SdkStrategyBridge.cs
@@ -1,8 +1,8 @@
 ﻿using System;
-using NinjaTrader.NinjaScript;          // Strategy base type
+using NinjaTrader.NinjaScript;
 using NinjaTrader.NinjaScript.Strategies;
-using NT8.SDK;                          // SdkFacade
-using NT8.SDK.Abstractions;             // ISdk
+using NT8.SDK;
+using NT8.SDK.Abstractions;
 
 namespace NinjaTrader.NinjaScript.Strategies
 {
@@ -10,7 +10,7 @@ namespace NinjaTrader.NinjaScript.Strategies
     /// SdkStrategyBridge
     /// - On load: instantiate SDK and print startup banner.
     /// - On each tick: forward time/price to SDK (no orders).
-    /// - Every 5 seconds (chart time): print the latest SDK tick for visibility.
+    /// - Every 5 seconds: print latest tick; also print bias transitions.
     /// </summary>
     public class SdkStrategyBridge : Strategy
     {
@@ -18,13 +18,15 @@ namespace NinjaTrader.NinjaScript.Strategies
         private DateTime _lastPrint = DateTime.MinValue;
         private readonly TimeSpan _printEvery = TimeSpan.FromSeconds(5);
 
+        private string _lastBias = null; // "LONG", "SHORT", "FLAT", or null until known
+
         protected override void OnStateChange()
         {
             if (State == State.SetDefaults)
             {
                 Name = "SdkStrategyBridge";
-                Calculate = Calculate.OnEachTick;   // tick-level updates
-                IsUnmanaged = false;                // no orders here
+                Calculate = Calculate.OnEachTick;
+                IsUnmanaged = false;
                 IsInstantiatedOnEachOptimizationIteration = false;
             }
             else if (State == State.DataLoaded)
@@ -39,12 +41,11 @@ namespace NinjaTrader.NinjaScript.Strategies
             if (_sdk == null || CurrentBar < 0)
                 return;
 
-            // Forward the latest bar's time/price into the SDK (no orders).
             DateTime t = Time[0];
             double price = Close[0];
             _sdk.OnPriceTick(t, price);
 
-            // Every 5 seconds of chart time, print latest SDK tick if available.
+            // Periodic latest-tick print
             if (_lastPrint == DateTime.MinValue || (t - _lastPrint) >= _printEvery)
             {
                 DateTime lt;
@@ -58,6 +59,24 @@ namespace NinjaTrader.NinjaScript.Strategies
                     Print("[SDK] no ticks yet");
                 }
                 _lastPrint = t;
+            }
+
+            // Bias transitions
+            bool isLong;
+            bool isShort;
+            if (_sdk.TryGetSignal(out isLong, out isShort))
+            {
+                string bias = isLong ? "LONG" : (isShort ? "SHORT" : "FLAT");
+                if (!string.Equals(bias, _lastBias, StringComparison.Ordinal))
+                {
+                    Print("[SDK] bias => " + bias);
+                    _lastBias = bias;
+                }
+            }
+            else if (_lastBias != "WARMING")
+            {
+                Print("[SDK] bias => WARMING");
+                _lastBias = "WARMING";
             }
         }
     }


### PR DESCRIPTION
Bridge strategy prints latest SDK tick every 5s and bias transitions using ISdk.TryGetSignal. Guard-safe.