### PR TITLE
Implement order routing methods

### DIFF
--- a/NT8Bridge/Nt8Orders.cs
+++ b/NT8Bridge/Nt8Orders.cs
@@ -1,4 +1,6 @@
-﻿using System;
+using System;
+using System.Collections.Generic;
+using NinjaTrader.Cbi;
 using NinjaTrader.NinjaScript;
 using NinjaTrader.NinjaScript.Strategies;
 using NT8.SDK.Abstractions;
@@ -12,6 +14,7 @@ namespace NT8.SDK.NT8Bridge
     public sealed class Nt8Orders : IOrders
     {
         private readonly Strategy _strategy;
+        private readonly Dictionary<Guid, Order> _orders = new Dictionary<Guid, Order>();
 
         public Nt8Orders(Strategy strategy)
         {
@@ -21,18 +24,84 @@ namespace NT8.SDK.NT8Bridge
 
         public void Submit(OrderIntent intent)
         {
-            // TODO: map intents to actual NT8 order methods (EnterLong/EnterShort/ExitXXX).
-            // Guard-safe placeholder to keep compile green until order routing is wired.
+            if (intent == null)
+                throw new ArgumentNullException("intent");
+
+            dynamic i = intent;
+
+            Guid clientId = i.ClientOrderId;
+            bool isLong = i.IsLong;
+            int quantity = i.Quantity;
+            decimal stop = i.Stop;
+            decimal target = i.Target;
+            string oco = i.OcoId;
+
+            if (stop != 0m)
+                _strategy.SetStopLoss(oco, CalculationMode.Price, (double)stop, false);
+
+            if (target != 0m)
+                _strategy.SetProfitTarget(oco, CalculationMode.Price, (double)target);
+
+            Order order = isLong
+                ? _strategy.EnterLong(quantity, oco)
+                : _strategy.EnterShort(quantity, oco);
+
+            if (order != null && clientId != Guid.Empty)
+                _orders[clientId] = order;
         }
 
-        public void Modify(OrderIds ids, OrderIntent intent)
+        public void Cancel(Guid clientOrderId)
         {
-            // TODO: adjust stop/target for provided ids.
+            Order order;
+            if (_orders.TryGetValue(clientOrderId, out order) && order != null)
+                _strategy.CancelOrder(order);
         }
 
-        public void Cancel(OrderIds ids)
+        public void Modify(Guid clientOrderId, decimal newStop, decimal newTarget)
         {
-            // TODO: cancel by ids where available; no-op if ids.IsEmpty.
+            Order order;
+            if (!_orders.TryGetValue(clientOrderId, out order) || order == null)
+                return;
+
+            if (newStop != 0m)
+                _strategy.ChangeOrder(order, order.Quantity, order.LimitPrice, (double)newStop);
+
+            if (newTarget != 0m)
+                _strategy.ChangeOrder(order, order.Quantity, (double)newTarget, order.StopPrice);
+        }
+
+        void IOrders.Modify(OrderIds ids, OrderIntent intent)
+        {
+            if (ids.IsEmpty)
+                return;
+
+            dynamic i = intent;
+            decimal stop = i.Stop;
+            decimal target = i.Target;
+            Guid g;
+
+            if (!string.IsNullOrEmpty(ids.Stop) && Guid.TryParse(ids.Stop, out g))
+                Modify(g, stop, 0m);
+
+            if (!string.IsNullOrEmpty(ids.Target) && Guid.TryParse(ids.Target, out g))
+                Modify(g, 0m, target);
+        }
+
+        void IOrders.Cancel(OrderIds ids)
+        {
+            if (ids.IsEmpty)
+                return;
+
+            Guid g;
+            if (!string.IsNullOrEmpty(ids.Entry) && Guid.TryParse(ids.Entry, out g))
+                Cancel(g);
+
+            if (!string.IsNullOrEmpty(ids.Stop) && Guid.TryParse(ids.Stop, out g))
+                Cancel(g);
+
+            if (!string.IsNullOrEmpty(ids.Target) && Guid.TryParse(ids.Target, out g))
+                Cancel(g);
         }
     }
 }
+


### PR DESCRIPTION
## Summary
- route order intents to NinjaTrader API
- support GUID-based cancellation and modification

## Testing
- `pwsh -NoLogo -NoProfile -File tools/guard.ps1` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a168b1bfc48329ae790a499b1e9d35