### PR TITLE
Use builder to construct full SDK in NT8 strategy shell

### DIFF
--- a/Strategies/SdkStrategyShell.cs
+++ b/Strategies/SdkStrategyShell.cs
@@ -3,6 +3,7 @@ using NinjaTrader.NinjaScript;
 using NinjaTrader.NinjaScript.Strategies;
 using NT8.SDK.Abstractions;
 using NT8.SDK.Facade;
+using NT8.SDK.NT8Bridge;
 
 namespace NinjaTrader.NinjaScript.Strategies
 {
@@ -23,7 +24,10 @@ namespace NinjaTrader.NinjaScript.Strategies
             }
             else if (State == State.DataLoaded)
             {
-                _sdk = new SdkFacade();
+                _sdk = new SdkBuilder()
+                    .WithDefaults()
+                    .WithOrders(new Nt8Orders(this))
+                    .Build();
                 Print(_sdk.StartupBanner);
             }
         }


### PR DESCRIPTION
## Summary
- build SDK via `SdkBuilder.WithDefaults().WithOrders(new Nt8Orders(this))`
- add Nt8Orders adapter for order routing instead of facade

## Testing
- `python tools/nt8_guard.py --fail-on-warn`
- `pwsh tools/guard.ps1` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: package not found)*
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a16c04a4fc832982817e79345e045b