### PR TITLE
feat: print startup banner on configure

### DIFF
--- a/Strategies/SdkStrategyShell.cs
+++ b/Strategies/SdkStrategyShell.cs
@@ -22,6 +22,10 @@ namespace NinjaTrader.NinjaScript.Strategies
                 Name = "SdkStrategyShell";
                 Calculate = Calculate.OnEachTick;
             }
+            else if (State == State.Configure)
+            {
+                Print(NT8.SDK.Common.StartupBanner.Get());
+            }
             else if (State == State.DataLoaded)
             {
                 _sdk = new SdkBuilder()


### PR DESCRIPTION
## Summary
- print SDK startup banner during Strategy configure state to verify DLL

## Testing
- `pwsh tools/guard.ps1` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: Unable to locate package powershell)*
- `python tools/nt8_guard.py`

------
https://chatgpt.com/codex/tasks/task_e_68a16f76955483298d7be81601327f3e