### PR TITLE
Add trailing stop parity test

### DIFF
--- a/QA.TestKit/TrailingParityTests.cs
+++ b/QA.TestKit/TrailingParityTests.cs
@@ -1,0 +1,28 @@
+using System;
+using NT8.SDK.Trailing;
+using Xunit;
+
+namespace NT8.SDK.QA.TestKit
+{
+    public class TrailingParityTests
+    {
+        [Fact]
+        public void TrailingNeverLoosensStop()
+        {
+            var trailing = new TrailingEngine();
+            trailing.Reset();
+
+            double[] prices = { 100, 101, 102, 101.5, 103 };
+            double stop = double.MinValue;
+
+            foreach (var p in prices)
+            {
+                trailing.Update(p);
+                var newStop = trailing.GetStopLoss(p);
+                if (stop != double.MinValue)
+                    Assert.True(newStop >= stop, "Trailing stop should not loosen");
+                stop = newStop;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add TrailingParityTests ensuring TrailingEngine stops never loosen

## Testing
- `dotnet test`
- `pwsh tools/guard.ps1` *(fails: C# files found at repo root)*

------
https://chatgpt.com/codex/tasks/task_e_68a1741e57cc8329bb6d12e1d63a07b5