### PR TITLE
guard: fail if QA summary missing

### DIFF
--- a/tools/guard.ps1
+++ b/tools/guard.ps1
@@ -47,3 +47,8 @@ if ($errors.Count) {
 } else {
   Write-Host 'Guard passed.'
 }
+
+if (-not (Test-Path "qa/summary.json")) {
+  Write-Error "Missing QA summary: qa/summary.json"
+  exit 1
+}


### PR DESCRIPTION
## Summary
- fail guard script when QA summary JSON is missing

## Testing
- `pwsh tools/guard.ps1` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68a17dbbf1fc832982e000da8db5af21