### PR TITLE
feat: add order submission telemetry

### DIFF
--- a/NT8Bridge/Nt8Orders.cs
+++ b/NT8Bridge/Nt8Orders.cs
@@ -13,11 +13,13 @@ namespace NT8Bridge
     public sealed class Nt8Orders : IOrders
     {
         private readonly Strategy _strategy;
+        private readonly dynamic _telemetry;
 
-        public Nt8Orders(Strategy strategy)
+        public Nt8Orders(Strategy strategy, dynamic telemetry = null)
         {
             if (strategy == null) throw new ArgumentNullException("strategy");
             _strategy = strategy;
+            _telemetry = telemetry;
         }
 
         public OrderIds Submit(OrderIntent intent)
@@ -57,6 +59,12 @@ namespace NT8Bridge
                 else
                     order = _strategy.EnterShortStopLimit(intent.Quantity, price, price, intent.Signal);
             }
+
+            _telemetry?.Emit("OrderSubmitted", "New order routed", new {
+                type = intent.Type.ToString(),
+                quantity = intent.Quantity,
+                price = intent.Price
+            });
 
             if (order != null && !string.IsNullOrEmpty(intent.OcoGroup))
                 order.Oco = intent.OcoGroup;


### PR DESCRIPTION
## Summary
- log order submissions via telemetry after routing
- accept optional telemetry sink in Nt8Orders bridge

## Testing
- `python tools/nt8_guard.py --fail-on-warn`
- ⚠️ `apt-get install -y powershell` *(missing package)*

------
https://chatgpt.com/codex/tasks/task_e_68a17da752108329beb746d2c2979e97