### PR TITLE
feat: print instrument at configure

### DIFF
--- a/Strategies/SdkStrategyShell.cs
+++ b/Strategies/SdkStrategyShell.cs
@@ -25,6 +25,7 @@ namespace NinjaTrader.NinjaScript.Strategies
             else if (State == State.Configure)
             {
                 Print(NT8.SDK.Common.StartupBanner.Get());
+                Print($"[NT8 SDK] Starting strategy on {Instrument.FullName} at {Time[0]}");
             }
             else if (State == State.DataLoaded)
             {


### PR DESCRIPTION
## Summary
- log instrument name and timestamp when strategy enters Configure state

## Testing
- `dotnet build SDK.sln`
- `python3 tools/nt8_guard.py --fail-on-warn`
- `pwsh -File tools/guard.ps1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a17d9a07508329b1c300fb378ee588