### PR TITLE
Add RiskCapsConfig for CLI risk cap loading

### DIFF
--- a/CLI/ConfigLoader.cs
+++ b/CLI/ConfigLoader.cs
@@ -1,0 +1,21 @@
+using System;
+using System.IO;
+using Newtonsoft.Json;
+
+namespace NT8.SDK.CLI
+{
+    public class RiskCapsConfig
+    {
+        public double DailyCap { get; set; }
+        public double WeeklyCap { get; set; }
+
+        public static RiskCapsConfig Load(string path)
+        {
+            if (!File.Exists(path))
+                throw new FileNotFoundException("Config file not found", path);
+
+            var json = File.ReadAllText(path);
+            return JsonConvert.DeserializeObject<RiskCapsConfig>(json);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add RiskCapsConfig to load daily and weekly caps from JSON config files for CLI use

## Testing
- `pwsh tools/guard.ps1` *(command not found)*
- `xbuild` *(default XML namespace of the project must be the MSBuild XML namespace)*

------
https://chatgpt.com/codex/tasks/task_e_68a17d8bf7d88329a57d5dd5375bafa3