### PR TITLE
feat: guard order submission with caps and package SDK

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,59 @@
+name: Build SDK
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Cache NuGet
+        uses: actions/cache@v4
+        with:
+          path: ~\AppData\Local\NuGet\Cache
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Restore
+        run: dotnet restore SDK.csproj
+
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v2
+
+      - name: Build (Release, net48)
+        run: msbuild SDK.csproj /t:Build /p:Configuration=Release /v:m
+
+      - name: Package SDK bundle
+        run: |
+          mkdir dist
+          powershell Compress-Archive -Path `
+            bin/Release/net48/NT8.SDK.Compat.dll, `
+            NT8Bridge\*.cs, `
+            Strategies\*Shell*.cs, `
+            README-Compat.md `
+            -DestinationPath dist\nt8-sdk-bundle.zip
+
+      - name: List outputs
+        shell: pwsh
+        run: |
+          Get-ChildItem -Recurse -File .\\bin\\Release\\net48 |
+            Select-Object FullName, Length, LastWriteTime |
+            Format-Table -AutoSize
+
+      - name: Upload artifact (NT8.SDK.dll)
+        uses: actions/upload-artifact@v4
+        with:
+          name: NT8.SDK-bin
+          path: bin/Release/net48/**


### PR DESCRIPTION
## Summary
- enforce daily and weekly PnL caps before submitting strategy orders
- package SDK DLL and shell strategies into a distributable zip in CI

## Testing
- `dotnet build SDK.csproj`
- ⚠️ `tools/guard.ps1` (PowerShell not installed)


------
https://chatgpt.com/codex/tasks/task_e_68a17cc32a5083299bae4e5c1eb880da