### PR TITLE
Add golden path QA test

### DIFF
--- a/QA.TestKit/BacktestGoldenPath.cs
+++ b/QA.TestKit/BacktestGoldenPath.cs
@@ -1,0 +1,20 @@
+using NUnit.Framework;
+using NT8.SDK.TestKit;
+
+namespace NT8.SDK.QA.TestKit
+{
+    public class BacktestGoldenPath
+    {
+        [Test]
+        public void StrategyShouldMeetBaselinePerformance()
+        {
+            var sdk = new SdkBuilder().WithDefaults().Build();
+            var harness = new BacktestHarness(sdk);
+
+            var result = harness.Run("ES", "2025-01-01", "2025-01-15");
+
+            Assert.LessOrEqual(result.MaxDrawdown, 1000, "MaxDrawdown exceeded");
+            Assert.GreaterOrEqual(result.HitRate, 50.0, "HitRate below 50%");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add BacktestGoldenPath QA test to assert baseline performance using SdkBuilder defaults

## Testing
- `python3 tools/nt8_guard.py`
- `dotnet test` *(no tests found)*
- `dotnet build`
- `pwsh -NoLogo -NoProfile -File tools/guard.ps1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a17cdacc74832993f76a7cbe8425ea