### PR TITLE
Check risk cap lockout before trade tick

### DIFF
--- a/Risk/RiskCaps.cs
+++ b/Risk/RiskCaps.cs
@@ -1,0 +1,57 @@
+using System;
+
+namespace NT8.SDK.Risk
+{
+    /// <summary>
+    /// Aggregates multiple risk cap checks (daily, weekly, trailing) and
+    /// reports when trading should be locked out.
+    /// </summary>
+    public class RiskCaps
+    {
+        private readonly DailyWeeklyCaps _dailyWeekly;
+        private readonly TrailingDrawdown _trailing;
+        private double _netEquity;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RiskCaps"/> class.
+        /// </summary>
+        /// <param name="dailyLimit">Maximum loss allowed per day.</param>
+        /// <param name="weeklyLimit">Maximum loss allowed per week.</param>
+        /// <param name="trailingLimit">Maximum allowed trailing drawdown.</param>
+        /// <param name="initialEquity">Initial account equity.</param>
+        public RiskCaps(double dailyLimit, double weeklyLimit, double trailingLimit, double initialEquity)
+        {
+            _dailyWeekly = new DailyWeeklyCaps(dailyLimit, weeklyLimit);
+            _trailing = trailingLimit > 0 ? new TrailingDrawdown(initialEquity, trailingLimit) : null;
+            _netEquity = initialEquity;
+        }
+
+        /// <summary>
+        /// Applies realized PnL and updates internal caps.
+        /// </summary>
+        /// <param name="realizedPnL">The realized profit or loss.</param>
+        /// <param name="when">Time the PnL was realized.</param>
+        /// <param name="netEquity">Current net equity value.</param>
+        public void ApplyPnL(double realizedPnL, DateTime when, double netEquity)
+        {
+            _dailyWeekly?.ApplyPnL(realizedPnL, when);
+            _netEquity = netEquity;
+            _trailing?.ApplyPnL(netEquity);
+        }
+
+        /// <summary>
+        /// Determines whether any configured cap has been breached.
+        /// </summary>
+        /// <returns>True if a lockout is active; otherwise, false.</returns>
+        public bool IsLocked()
+        {
+            var now = DateTime.UtcNow;
+            if (_dailyWeekly != null && (_dailyWeekly.IsDailyLocked(now) || _dailyWeekly.IsWeeklyLocked(now)))
+                return true;
+            if (_trailing != null && _trailing.IsLocked(_netEquity))
+                return true;
+            return false;
+        }
+    }
+}
+

--- a/Strategies/SdkStrategyShell.cs
+++ b/Strategies/SdkStrategyShell.cs
@@ -16,7 +16,7 @@ namespace NinjaTrader.NinjaScript.Strategies
     public class SdkStrategyShell : Strategy
     {
         private ISdk _sdk;
-        private DailyWeeklyCaps _caps;
+        private RiskCaps riskCaps;
 
         protected override void OnStateChange()
         {
@@ -36,7 +36,7 @@ namespace NinjaTrader.NinjaScript.Strategies
                     .WithDefaults()
                     .WithOrders(new Nt8Orders(this))
                     .Build();
-                _caps = new DailyWeeklyCaps(double.MaxValue, double.MaxValue);
+                riskCaps = new RiskCaps(double.MaxValue, double.MaxValue, double.MaxValue, 0);
                 Print(_sdk.StartupBanner);
             }
         }
@@ -45,14 +45,9 @@ namespace NinjaTrader.NinjaScript.Strategies
         {
             if (_sdk == null || CurrentBar < 0) return;
 
-            double currentPnL = 0;
-            if (_caps != null && (_caps.IsDailyLocked(Time[0]) || _caps.IsWeeklyLocked(Time[0])))
+            if (riskCaps != null && riskCaps.IsLocked())
             {
-                var telemetry = new FileTelemetry("risk.log", "jsonl");
-                telemetry.Emit("RiskLockout", "Trade blocked by Daily or Weekly Cap", new {
-                    date = Time[0],
-                    pnl = currentPnL
-                });
+                Print("⚠️ Trade skipped: risk cap lockout active.");
                 return;
             }
 


### PR DESCRIPTION
## Summary
- Add RiskCaps aggregator to track daily, weekly, and trailing drawdown limits
- Prevent trade processing in `SdkStrategyShell` when RiskCaps indicates a lockout

## Testing
- `python3 tools/nt8_guard.py`
- `pwsh --version` *(fails: command not found)*
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1804b0ac88329b0c7250f2e8e48c1