### PR TITLE
feat: print loaded risk caps

### DIFF
--- a/CLI/ConfigLoader.cs
+++ b/CLI/ConfigLoader.cs
@@ -8,6 +8,7 @@ namespace NT8.SDK.CLI
     {
         public double DailyCap { get; set; }
         public double WeeklyCap { get; set; }
+        public double TrailingLimit { get; set; }
 
         public static RiskCapsConfig Load(string path)
         {
@@ -15,7 +16,9 @@ namespace NT8.SDK.CLI
                 throw new FileNotFoundException("Config file not found", path);
 
             var json = File.ReadAllText(path);
-            return JsonConvert.DeserializeObject<RiskCapsConfig>(json);
+            var config = JsonConvert.DeserializeObject<RiskCapsConfig>(json);
+            Console.WriteLine($"✅ Loaded risk caps: Daily={config.DailyCap}, Weekly={config.WeeklyCap}, Trailing={config.TrailingLimit}");
+            return config;
         }
     }
 }


### PR DESCRIPTION
## Summary
- log risk cap values on config load for startup visibility
- extend `RiskCapsConfig` with `TrailingLimit`

## Testing
- `pwsh tools/guard.ps1` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: Unable to locate package powershell)*

------
https://chatgpt.com/codex/tasks/task_e_68a180a1c13883298fbeea585fc4bd85