### PR TITLE
chore: include QA summary in packaging

### DIFF
--- a/scripts/package-sdk.ps1
+++ b/scripts/package-sdk.ps1
@@ -1,0 +1,20 @@
+$ErrorActionPreference = 'Stop'
+
+$repo     = Split-Path -Parent $PSScriptRoot
+$outDir   = Join-Path $repo 'out'
+$buildDir = Join-Path $outDir 'build'
+$zipPath  = Join-Path $outDir 'nt8-sdk-bundle.zip'
+
+Remove-Item $buildDir -Recurse -Force -ErrorAction SilentlyContinue
+New-Item -ItemType Directory -Force -Path $buildDir | Out-Null
+New-Item -ItemType Directory -Force -Path $outDir   | Out-Null
+
+Copy-Item (Join-Path $repo 'bin\Release\net48\NT8.SDK.dll') $buildDir -Force
+Copy-Item (Join-Path $repo 'NT8Bridge') (Join-Path $buildDir 'NT8Bridge') -Recurse -Force
+Copy-Item (Join-Path $repo 'Strategies') (Join-Path $buildDir 'Strategies') -Recurse -Force
+Copy-Item (Join-Path $repo 'docs\NT8-Install.md') (Join-Path $buildDir 'docs') -Force
+
+Copy-Item qa\summary.json $buildDir\qa_summary.json -Force
+
+Compress-Archive -Path "$buildDir\*" -DestinationPath $zipPath -Force
+Write-Host "✅ NT8 SDK bundle created: $zipPath"


### PR DESCRIPTION
## Summary
- stage SDK files into `out/build` and package them into a zip
- copy QA summary to the zip root before compression

## Testing
- `pwsh -File tools/test.ps1` *(fails: command not found)*
- `pwsh -File tools/guard.ps1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a180aed1808329b8a7c479da4acbc7