### PR TITLE
chore(labels): sync standard labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,6 @@ Institutional-grade, risk-compliant NinjaTrader 8 SDK for automated futures trad
 - `IRisk.EvaluateEntry` implementations must accept an empty string without throwing.
 - Trailing stop logic must never loosen stops once tightened.
 - Run `python tools/nt8_guard.py --fail-on-warn` and build with `mcs` before sending a pull request.
+
+## Project Labels
+This repo uses standardized labels: `decision`, `docs`, `ci`, `build`, `feature`, `fix`, `bug`, `risk`, `telemetry`, `task`.


### PR DESCRIPTION
## Summary
- document standard labels in README

## Testing
- `pwsh -NoLogo -Command "./tools/guard.ps1"` *(fails: command not found)*
- `powershell -NoLogo -Command "./tools/guard.ps1"` *(fails: command not found)*
- `python3 tools/nt8_guard.py --fail-on-warn`


------
https://chatgpt.com/codex/tasks/task_e_68a1ff3cb95c8329b94336f595c823e4