### PR TITLE
CI Observability: PR QA KPI comment

### DIFF
--- a/.github/workflows/qa-comment.yml
+++ b/.github/workflows/qa-comment.yml
@@ -1,0 +1,27 @@
+name: QA PR Comment
+on:
+  workflow_run:
+    workflows: ["NT8 Guard"]
+    types: [completed]
+jobs:
+  comment:
+    if: ${{ github.event.workflow_run.conclusion != 'cancelled' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 'lts/*' }
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+      - name: Determine PR number
+        id: pr
+        run: |
+          echo "pr=$(jq -r '.pull_requests[0].number // empty' <<< '${{ toJson(github.event.workflow_run) }}')" >> $GITHUB_OUTPUT
+      - name: Skip if not a PR
+        if: ${{ steps.pr.outputs.pr == '' }}
+        run: echo "Not a PR run; skipping."
+      - name: Post QA KPIs comment
+        if: ${{ steps.pr.outputs.pr != '' }}
+        run: ./scripts/post-qa-comment.sh "${{ steps.pr.outputs.pr }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/post-qa-comment.sh
+++ b/scripts/post-qa-comment.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+PR_NUMBER="${1:-}"
+FILE="qa/summary.json"
+if [ ! -f "$FILE" ] && [ -f "**/qa/summary.json" ]; then FILE="**/qa/summary.json"; fi
+if ! ls $FILE >/dev/null 2>&1; then
+  echo "No qa/summary.json found; skipping comment."
+  exit 0
+fi
+MAR=$(jq -r '.MAR // .metrics.MAR // "n/a"' $FILE 2>/dev/null || echo "n/a")
+HIT=$(jq -r '.HitRate // .metrics.HitRate // "n/a"' $FILE 2>/dev/null || echo "n/a")
+MDD=$(jq -r '.MaxDrawdown // .metrics.MaxDrawdown // "n/a"' $FILE 2>/dev/null || echo "n/a")
+cat > /tmp/qa.md <<EOF
+**QA Summary**
+- MAR: \`$MAR\`
+- Hit Rate: \`$HIT\`
+- Max DD: \`$MDD\`
+
+_Source: \`qa/summary.json\`_
+EOF
+gh pr comment "$PR_NUMBER" -F /tmp/qa.md
+


### PR DESCRIPTION
## Summary
- auto-post QA KPIs MAR/HitRate/MaxDD as PR comment when `qa/summary.json` present
- workflow triggers after NT8 Guard run to drive observability

## Testing
- `bash -n scripts/post-qa-comment.sh`
- `pwsh tools/guard.ps1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1fe5a65448329be8fd3e4b03ba304