### PR TITLE
CI Packaging: sdk_bundle.zip on successful guard run

### DIFF
--- a/.github/workflows/package-sdk.yml
+++ b/.github/workflows/package-sdk.yml
@@ -1,0 +1,23 @@
+name: Package SDK
+on:
+  workflow_run:
+    workflows: ["NT8 Guard"]
+    types: [completed]
+jobs:
+  package:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Collect artifacts (best-effort)
+        run: |
+          mkdir -p dist
+          mkdir -p qa || true
+          test -f qa/summary.json || true
+          zip -r dist/sdk_bundle.zip ./bin ./docs/runbook.md qa/summary.json 2>/dev/null || true
+      - name: Upload SDK bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdk-bundle
+          path: dist/sdk_bundle.zip
+          if-no-files-found: warn

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,0 +1,4 @@
+# Go-Live Runbook (Quick)
+- Ensure CI green on `main`
+- Confirm artifacts: `sdk_bundle.zip`, `qa/summary.json`
+- SIM smoke: caps print, gating blocks, telemetry present


### PR DESCRIPTION
## Summary
- produce sdk_bundle.zip after NT8 Guard completes
- include runbook + QA summary in bundle

## Testing
- `python tools/nt8_guard.py`

------
https://chatgpt.com/codex/tasks/task_e_68a1fe4ed9308329a4f919e7b2aed3aa