### PR TITLE
Re-enable branch protection (require guard + build checks + 1 review)

### DIFF
--- a/docs/ops/branch-protection.md
+++ b/docs/ops/branch-protection.md
@@ -1,0 +1,16 @@
+# Branch Protection — main
+To (re)enable:
+```bash
+OWNER=moshin34 REPO=nt8-sdk-foundation-v3 BRANCH=main GITHUB_TOKEN=*** \
+bash scripts/enable-branch-protection.sh
+```
+
+Required checks (current):
+
+* NT8 Guard (layout-aware) / guard
+* NT8 Guard / build-test   (temporary)
+* Guard & Build / guard
+* Guard & Build / build
+* QA Validate / validate
+* Code scanning results / CodeQL
+* CodeQL / analyze

--- a/scripts/enable-branch-protection.sh
+++ b/scripts/enable-branch-protection.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+: "${GITHUB_TOKEN:?}"; : "${OWNER:?}"; : "${REPO:?}"; : "${BRANCH:=main}"
+
+api="https://api.github.com/repos/${OWNER}/${REPO}/branches/${BRANCH}/protection"
+payload=$(cat <<'JSON'
+{
+  "required_status_checks": {
+    "strict": false,
+    "contexts": [
+      "NT8 Guard (layout-aware) / guard",
+      "NT8 Guard / build-test",        // temporary shim — remove after hardening
+      "Guard & Build / guard",
+      "Guard & Build / build",
+      "QA Validate / validate",
+      "Code scanning results / CodeQL",
+      "CodeQL / analyze"
+    ]
+  },
+  "enforce_admins": true,
+  "required_pull_request_reviews": {
+    "required_approving_review_count": 1,
+    "dismiss_stale_reviews": false
+  },
+  "restrictions": null
+}
+JSON
+)
+
+curl -sS -X PUT -H "Authorization: token ${GITHUB_TOKEN}" \
+     -H "Accept: application/vnd.github+json" \
+     --data "${payload}" "${api}"
+
+echo "✅ Branch protection restored for ${OWNER}/${REPO}@${BRANCH}"
+echo "NOTE: 'NT8 Guard / build-test' is a temporary shim; remove after guard hardening."


### PR DESCRIPTION
## Summary
- add script to restore branch protection requiring guard, build, QA, and CodeQL checks with one approving review
- document how to re-enable branch protection and list required checks

## Testing
- `pwsh -NoLogo -NoProfile -NonInteractive -File tools/guard.ps1` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: Unable to locate package powershell)*

------
https://chatgpt.com/codex/tasks/task_e_68a2861677e08329bc17a2976ada2c8e