### PR TITLE
fix(ci): restore + sdkinfo + packaging

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,6 +21,6 @@ jobs:
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '8.0.x'
-      - run: dotnet restore SDK.sln || true
-      - run: dotnet build SDK.sln -c Release --no-restore || true
+      - run: dotnet restore SDK.sln
+      - run: dotnet build SDK.sln -c Release --no-restore
       - uses: github/codeql-action/analyze@v3

--- a/.github/workflows/guard-build.yml
+++ b/.github/workflows/guard-build.yml
@@ -26,10 +26,17 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '8.0.x'
-      - name: Restore (non-fatal)
-        run: dotnet restore || true
-      - name: Build (non-fatal)
-        run: dotnet build --no-restore -c Release || true
+      - name: Restore
+        run: dotnet restore
+      - name: Build
+        run: dotnet build --no-restore -c Release
+      - name: Package SDK
+        run: |
+          mkdir -p dist package
+          cp qa/summary.json package/ 2>/dev/null || true
+          find Risk Config -maxdepth 2 -type f \( -name '*.json' -o -name '*.log' -o -name '*.config' \) -exec cp --parents {} package/ \; 2>/dev/null || true
+          cp -r bin/Release package/bin 2>/dev/null || true
+          zip -r dist/SDK.zip package
       - name: Upload QA summary (best-effort)
         if: always()
         uses: actions/upload-artifact@v4
@@ -39,3 +46,9 @@ jobs:
             qa/summary.json
             **/qa/summary.json
           if-no-files-found: warn
+      - name: Upload SDK package
+        uses: actions/upload-artifact@v4
+        with:
+          name: SDK
+          path: dist/SDK.zip
+          if-no-files-found: error

--- a/Facade/SdkFacade.cs
+++ b/Facade/SdkFacade.cs
@@ -2,6 +2,7 @@ using System;
 using NT8.SDK.Abstractions;
 using NT8.SDK.Common;
 using StartupBannerCommon = NT8.SDK.Common.StartupBanner;
+using SdkInfoRef = NT8.SDK.SdkInfo;
 
 namespace NT8.SDK
 {
@@ -18,7 +19,7 @@ namespace NT8.SDK
         /// <summary>Semantic SDK version (e.g., 0.1.0).</summary>
         public string SdkVersion
         {
-            get { return SdkInfo.Version; }
+            get { return SdkInfoRef.Version; }
         }
 
         /// <summary>Startup banner string suitable for logging or UI display.</summary>


### PR DESCRIPTION
## Summary
- include dotnet restore in CI workflows
- hook SdkFacade up to SdkInfo
- package build outputs and configs into SDK.zip

## Testing
- `dotnet restore`
- `dotnet build -c Release`
- `zip -r dist/SDK.zip package`


------
https://chatgpt.com/codex/tasks/task_e_68a2a6ff3ed48329930a5c75cdee9027