### PR TITLE
docs+ci(strategy): add NinjaScript contract, lint, and canonical template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,14 +1,13 @@
-## What changed?
--
+## Summary
+- Add/modify NinjaScript strategies or related docs.
 
-## Why?
--
+## Checklist
+- [ ] Read `docs/ninjascript_contract.md`
+- [ ] Strategy compiles in **NinjaTrader 8 Editor**
+- [ ] Includes required `using` lines and correct namespace
+- [ ] `OnOrderUpdate` signature matches contract (has `int filled`)
+- [ ] `OnBarUpdate` includes `BarsRequiredToTrade` guard
+- [ ] No async/await, records, init-only, or LINQ query syntax
 
-## How tested?
-- [ ] Guard passed (`powershell .\tools\guard.ps1`)
-- [ ] NT8 compile ok (if NT8Bridge/Strategies touched)
-
-## Risk / Rollback
--
-
-## Screenshots / Logs
+## Notes
+Attach NT8 compile confirmation (optional screenshot).

--- a/.github/workflows/ninjascript-lint.yml
+++ b/.github/workflows/ninjascript-lint.yml
@@ -1,0 +1,20 @@
+name: NinjaScript Lint
+
+on:
+  pull_request:
+    paths:
+      - "NT8Strategies/**"
+      - "docs/ninjascript_contract.md"
+      - "tools/ninjascript_lint.ps1"
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+
+      - name: Run NinjaScript Lint (PowerShell Core)
+        shell: pwsh
+        run: |
+          ./tools/ninjascript_lint.ps1 -Path NT8Strategies

--- a/NT8Strategies/Templates/MyStrategyTemplate.cs
+++ b/NT8Strategies/Templates/MyStrategyTemplate.cs
@@ -1,0 +1,103 @@
+#region Using declarations
+using System;
+using NinjaTrader.Cbi;
+using NinjaTrader.Data;
+using NinjaTrader.Gui.Tools;
+using NinjaTrader.NinjaScript;
+using NinjaTrader.NinjaScript.Strategies;
+using NinjaTrader.NinjaScript.StrategyGenerator;
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+#endregion
+
+namespace NinjaTrader.NinjaScript.Strategies
+{
+    /// <summary>
+    /// Canonical compile-safe strategy template for NinjaTrader 8.
+    /// </summary>
+    public class MyStrategyTemplate : Strategy
+    {
+        private int period = 14;
+        private bool debugMode = false;
+
+        [NinjaScriptProperty]
+        [Range(1, int.MaxValue)]
+        [Display(Name = "Period", Order = 1, GroupName = "Parameters")]
+        public int Period
+        {
+            get { return period; }
+            set { period = value; }
+        }
+
+        [NinjaScriptProperty]
+        [Display(Name = "Debug Mode", Order = 2, GroupName = "Parameters")]
+        public bool DebugMode
+        {
+            get { return debugMode; }
+            set { debugMode = value; }
+        }
+
+        protected override void OnStateChange()
+        {
+            if (State == State.SetDefaults)
+            {
+                Name = "MyStrategyTemplate";
+                Description = "Canonical compile-safe NinjaScript template.";
+                Calculate = Calculate.OnBarClose;
+                IsOverlay = false;
+                EntriesPerDirection = 1;
+                EntryHandling = EntryHandling.AllEntries;
+                IsExitOnSessionCloseStrategy = true;
+                ExitOnSessionCloseSeconds = 30;
+                BarsRequiredToTrade = 20;
+
+                Period = 14;
+                DebugMode = false;
+            }
+            else if (State == State.Configure)
+            {
+                SetStopLoss(CalculationMode.Ticks, 10);
+            }
+            else if (State == State.DataLoaded)
+            {
+                if (DebugMode)
+                    Print("=== MyStrategyTemplate initialized ===");
+            }
+        }
+
+        protected override void OnBarUpdate()
+        {
+            if (CurrentBar < BarsRequiredToTrade)
+                return;
+
+            if (Position.MarketPosition == MarketPosition.Flat)
+            {
+                EnterLong("LongEntry");
+
+                if (DebugMode)
+                    Print(Time[0] + " -> EnterLong executed @ " + Close[0]);
+            }
+            else if (DebugMode)
+            {
+                Print(Time[0] + " -> Current position: " + Position.MarketPosition);
+            }
+        }
+
+        protected override void OnOrderUpdate(
+            Order order, double limitPrice, double stopPrice, int quantity,
+            int filled, double averageFillPrice, OrderState orderState,
+            DateTime time, ErrorCode error, string nativeError)
+        {
+            if (DebugMode && order != null)
+                Print($"[OnOrderUpdate] {time:u} {order.Name} {orderState} qty={quantity} filled={filled} avg={averageFillPrice}");
+        }
+
+        protected override void OnExecutionUpdate(
+            Execution execution, string executionId, double price, int quantity,
+            MarketPosition marketPosition, string orderId, DateTime time)
+        {
+            if (DebugMode && execution != null)
+                Print($"[OnExecutionUpdate] {time:u} {execution.Order?.Name} {marketPosition} qty={quantity} price={price}");
+        }
+    }
+}

--- a/docs/ninjascript_contract.md
+++ b/docs/ninjascript_contract.md
@@ -1,0 +1,92 @@
+# NinjaScript Contract (NinjaTrader 8) — Ground Truth
+
+Purpose: eliminate compile errors by standardizing imports, namespace, lifecycle, and exact override signatures for NinjaTrader 8 strategies.
+
+## Namespace (must be exact)
+    namespace NinjaTrader.NinjaScript.Strategies
+    {
+        // ...
+    }
+
+## Required using lines
+    using System;
+    using NinjaTrader.Cbi;
+    using NinjaTrader.Data;
+    using NinjaTrader.Gui.Tools;
+    using NinjaTrader.NinjaScript;
+    using NinjaTrader.NinjaScript.Strategies;
+    using NinjaTrader.NinjaScript.StrategyGenerator;
+    using System.ComponentModel;
+    using System.ComponentModel.DataAnnotations;
+
+## Required lifecycle blocks
+    protected override void OnStateChange()
+    {
+        if (State == State.SetDefaults)
+        {
+            Name = "StrategyName";
+            Description = "Strategy description.";
+            Calculate = Calculate.OnBarClose; // exact enum
+            IsOverlay = false;
+            EntriesPerDirection = 1;
+            EntryHandling = EntryHandling.AllEntries;
+            IsExitOnSessionCloseStrategy = true;
+            ExitOnSessionCloseSeconds = 30;
+            BarsRequiredToTrade = 20;
+        }
+        else if (State == State.Configure)
+        {
+            // e.g., SetStopLoss(CalculationMode.Ticks, 10);
+        }
+        else if (State == State.DataLoaded)
+        {
+            // allocate indicators/fields if needed
+        }
+    }
+
+    protected override void OnBarUpdate()
+    {
+        if (CurrentBar < BarsRequiredToTrade)
+            return;
+
+        // your trading logic
+    }
+
+## Exact override signatures (do not change order or types)
+    protected override void OnOrderUpdate(
+        Order order, double limitPrice, double stopPrice, int quantity,
+        int filled, double averageFillPrice, OrderState orderState,
+        DateTime time, ErrorCode error, string nativeError)
+    {
+        // optional
+    }
+
+    protected override void OnExecutionUpdate(
+        Execution execution, string executionId, double price, int quantity,
+        MarketPosition marketPosition, string orderId, DateTime time)
+    {
+        // optional
+    }
+
+## Property attributes
+Use these attributes exactly for Strategy UI params:
+    [NinjaScriptProperty]
+    [Range(1, int.MaxValue)]
+    [Display(Name = "Period", Order = 1, GroupName = "Parameters")]
+    public int Period { get; set; }
+
+## Don’t use (will fail or drift in NT8)
+- async/await
+- LINQ query syntax in hot paths
+- record types, init-only setters, top-level statements
+- Unqualified or wrong enums (e.g., do not use MarketCalculate)
+
+## Self-Checklist (must be true)
+- [ ] File in `NinjaTrader.NinjaScript.Strategies` namespace
+- [ ] All required `using` lines present
+- [ ] `Calculate = Calculate.OnBarClose;`
+- [ ] `OnOrderUpdate` includes `int filled` with exact signature
+- [ ] `OnBarUpdate` has `if (CurrentBar < BarsRequiredToTrade) return;`
+- [ ] No async/await, records, init, or LINQ query syntax
+
+See `NT8Strategies/Templates/MyStrategyTemplate.cs` for the canonical template.

--- a/tools/ninjascript_lint.ps1
+++ b/tools/ninjascript_lint.ps1
@@ -35,12 +35,12 @@ function Test-File {
     if ($src -notmatch $onOrderSig) { $errors += "OnOrderUpdate signature incorrect (must include int filled in correct position)." }
 
     if ($errors.Count -gt 0) {
-        Write-Host "NinjaScript Lint Failed for $file:"
+        Write-Host "NinjaScript Lint Failed for ${file}:"
         $errors | ForEach-Object { Write-Host " - $_" }
         return $false
     }
 
-    Write-Host "NinjaScript Lint Passed: $file"
+    Write-Host "NinjaScript Lint Passed: ${file}"
     return $true
 }
 

--- a/tools/ninjascript_lint.ps1
+++ b/tools/ninjascript_lint.ps1
@@ -1,0 +1,65 @@
+param(
+    [Parameter(Mandatory=$false)]
+    [string] $Path = "NT8Strategies"
+)
+
+Write-Host "NinjaScript Lint: scanning $Path"
+
+function Test-File {
+    param([string]$file)
+
+    $src = Get-Content $file -Raw
+    $errors = @()
+
+    if ($src -notmatch 'namespace\s+NinjaTrader\.NinjaScript\.Strategies') { $errors += "Wrong or missing namespace." }
+
+    $requiredUsings = @(
+        'using\s+System;',
+        'using\s+NinjaTrader\.Cbi;',
+        'using\s+NinjaTrader\.Data;',
+        'using\s+NinjaTrader\.Gui\.Tools;',
+        'using\s+NinjaTrader\.NinjaScript;',
+        'using\s+NinjaTrader\.NinjaScript\.Strategies;',
+        'using\s+NinjaTrader\.NinjaScript\.StrategyGenerator;',
+        'using\s+System\.ComponentModel;',
+        'using\s+System\.ComponentModel\.DataAnnotations;'
+    )
+    foreach ($u in $requiredUsings) {
+        if ($src -notmatch $u) { $errors += "Missing using: $u" }
+    }
+
+    if ($src -notmatch 'Calculate\s*=\s*Calculate\.OnBarClose') { $errors += "Wrong or missing Calculate.OnBarClose." }
+    if ($src -notmatch 'if\s*\(\s*CurrentBar\s*<\s*BarsRequiredToTrade\s*\)\s*return;') { $errors += "Missing BarsRequiredToTrade guard in OnBarUpdate." }
+
+    $onOrderSig = 'OnOrderUpdate\s*\(\s*Order\s+order,\s*double\s+limitPrice,\s*double\s+stopPrice,\s*int\s+quantity,\s*int\s+filled,\s*double\s+averageFillPrice,\s*OrderState\s+orderState,\s*DateTime\s+time,\s*ErrorCode\s+error,\s*string\s+nativeError\s*\)'
+    if ($src -notmatch $onOrderSig) { $errors += "OnOrderUpdate signature incorrect (must include int filled in correct position)." }
+
+    if ($errors.Count -gt 0) {
+        Write-Host "NinjaScript Lint Failed for $file:"
+        $errors | ForEach-Object { Write-Host " - $_" }
+        return $false
+    }
+
+    Write-Host "NinjaScript Lint Passed: $file"
+    return $true
+}
+
+$targetFiles = @()
+
+if (Test-Path $Path) {
+    if ((Get-Item $Path).PSIsContainer) {
+        $targetFiles = Get-ChildItem -Path $Path -Recurse -Filter *.cs | ForEach-Object { $_.FullName }
+    } else {
+        $targetFiles = @($Path)
+    }
+} else {
+    Write-Host "Path not found: $Path"
+    exit 0
+}
+
+$failed = $false
+foreach ($f in $targetFiles) {
+    if (-not (Test-File -file $f)) { $failed = $true }
+}
+
+if ($failed) { exit 1 } else { exit 0 }


### PR DESCRIPTION
This PR introduces a compile-safety contract and pre-merge lint for NinjaScript:

- docs/ninjascript_contract.md — ground truth for imports, namespace, lifecycle, and exact override signatures
- tools/ninjascript_lint.ps1 — checks common NT8 pitfalls
- .github/workflows/ninjascript-lint.yml — runs the lint on PRs
- .github/PULL_REQUEST_TEMPLATE.md — includes “Compiled in NT8” checklist
- NT8Strategies/Templates/MyStrategyTemplate.cs — canonical compile-safe template

Why: AI/codegen often drifts on NT8 quirks (signatures, enums, attributes). This enforces correctness at the repo level and reduces round-trips during go-live.

Checklist:
- [x] Files added
- [x] Lint passes locally on the template (where pwsh available)
- [x] CI job added for PRs touching NT8 strategies

Create this as a PR from branch `feat/ninjascript-contract-and-template` into `main`. 

------
https://chatgpt.com/codex/tasks/task_e_68a2aeed6fe48329b9085f9f633c44fa