### PR TITLE
fix(strategy): account-level enforcement + continuous gating (market data)

### DIFF
--- a/docs/GO-LIVE-RUNBOOK.md
+++ b/docs/GO-LIVE-RUNBOOK.md
@@ -22,7 +22,10 @@
 - Disable `Debug Mode` after validation.
 - Confirm broker connection and instrument mapping in NT8.
 - Start strategy on live account with MaxContracts set conservatively.
+- **Position Sync**: Set Start behavior = **Wait until flat**; ensure account is flat before switching to Live.
 
 Notes:
 - Daily/Weekly PnL baselines approximate via session/week anchors.
 - Replace demo entry with your production signals as needed (logic block in `OnBarUpdate`).
+- Enforcement runs on market data ticks; on breach, working orders are cancelled and (when **UseAccountFlatten = true**) the account is flattened automatically.
+- Manual orders that violate caps while the strategy is enabled will be cancelled/flattened.


### PR DESCRIPTION
## Summary
- enforce account-level position caps and risk checks on each market data tick
- add optional account flattening via `UseAccountFlatten`

## Testing
- `pwsh -NoLogo -NoProfile -Command "./tools/ninjascript_lint.ps1 -Path NT8Strategies/Live/RiskCappedStrategy.cs"`


------
https://chatgpt.com/codex/tasks/task_e_68a2bb7953b48329ad7adfc43d6c66b3