### PR TITLE
test(Abstractions): add PortableRiskManager console tests + CI

### DIFF
--- a/.github/workflows/portable-risk-tests.yml
+++ b/.github/workflows/portable-risk-tests.yml
@@ -1,0 +1,31 @@
+name: PortableRiskManager Tests
+
+on:
+  pull_request:
+    paths:
+      - "Abstractions/Risk/**"
+      - "tools/tests/PortableRiskTests.cs"
+      - ".github/workflows/portable-risk-tests.yml"
+  push:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+
+      - name: Install mono
+        run: sudo apt-get update && sudo apt-get install -y mono-devel
+
+      - name: Compile tests with mcs
+        run: |
+          mcs -langversion:7.2 -target:exe -out:PortableRiskTests.exe \
+            Abstractions/Risk/Models.cs \
+            Abstractions/Risk/IRiskManager.cs \
+            Abstractions/Risk/PortableRiskManager.cs \
+            tools/tests/PortableRiskTests.cs
+
+      - name: Run tests with mono
+        run: mono PortableRiskTests.exe

--- a/tools/tests/PortableRiskTests.cs
+++ b/tools/tests/PortableRiskTests.cs
@@ -1,0 +1,76 @@
+using System;
+using NT8.SDK.Abstractions.Risk;
+
+public static class PortableRiskTests
+{
+    private static int fails = 0;
+
+    public static void Main()
+    {
+        Test_MaxContracts();
+        Test_DailyLoss();
+        Test_WeeklyLoss();
+        Test_TrailingDD();
+        Test_Allow();
+
+        if (fails > 0)
+        {
+            Console.WriteLine("FAILURES=" + fails);
+            Environment.Exit(1);
+        }
+        Console.WriteLine("ALL TESTS PASSED");
+        Environment.Exit(0);
+    }
+
+    private static void Assert(bool cond, string name)
+    {
+        if (!cond) { fails++; Console.WriteLine("FAIL: " + name); }
+        else Console.WriteLine("OK: " + name);
+    }
+
+    private static RiskResult Eval(RiskCaps caps, RiskSnapshot snap)
+    {
+        var rm = new PortableRiskManager();
+        return rm.Evaluate(caps, snap);
+    }
+
+    private static void Test_MaxContracts()
+    {
+        var caps = new RiskCaps { MaxContracts = 1 };
+        var snap = new RiskSnapshot { AccountQuantity = 2 };
+        var r = Eval(caps, snap);
+        Assert(r.Decision == RiskDecision.BlockMaxContracts, "MaxContracts blocks when qty>max");
+    }
+
+    private static void Test_DailyLoss()
+    {
+        var caps = new RiskCaps { DailyLossLimit = 500m };
+        var snap = new RiskSnapshot { DailyPnL = -500m };
+        var r = Eval(caps, snap);
+        Assert(r.Decision == RiskDecision.BlockDailyLoss, "Daily loss blocks at limit");
+    }
+
+    private static void Test_WeeklyLoss()
+    {
+        var caps = new RiskCaps { WeeklyLossLimit = 1000m };
+        var snap = new RiskSnapshot { WeeklyPnL = -1000m };
+        var r = Eval(caps, snap);
+        Assert(r.Decision == RiskDecision.BlockWeeklyLoss, "Weekly loss blocks at limit");
+    }
+
+    private static void Test_TrailingDD()
+    {
+        var caps = new RiskCaps { TrailingDrawdown = 1000m };
+        var snap = new RiskSnapshot { Equity = 0m, PeakEquity = 1500m };
+        var r = Eval(caps, snap);
+        Assert(r.Decision == RiskDecision.BlockTrailingDD, "TDD blocks when drawdown >= limit");
+    }
+
+    private static void Test_Allow()
+    {
+        var caps = new RiskCaps { MaxContracts = 3, DailyLossLimit = 500m, WeeklyLossLimit = 1500m, TrailingDrawdown = 2000m };
+        var snap = new RiskSnapshot { AccountQuantity = 1, DailyPnL = -100m, WeeklyPnL = -200m, Equity = 100m, PeakEquity = 300m };
+        var r = Eval(caps, snap);
+        Assert(r.Decision == RiskDecision.Allow, "Allow under all limits");
+    }
+}


### PR DESCRIPTION
## Summary
- add PortableRiskTests console app to exercise PortableRiskManager decisions via exit codes
- run PortableRiskManager tests in CI using Mono

## Testing
- `python tools/nt8_guard.py`
- `mcs -langversion:7.2 -target:exe -out:PortableRiskTests.exe Abstractions/Risk/Models.cs Abstractions/Risk/IRiskManager.cs Abstractions/Risk/PortableRiskManager.cs tools/tests/PortableRiskTests.cs`
- `mono PortableRiskTests.exe`


------
https://chatgpt.com/codex/tasks/task_e_68a2bfbf3c6c832997feaeefa0391ead