### PR TITLE
feat(config): add risk preset JSONs + portable loader

### DIFF
--- a/Abstractions/Config/RiskPreset.cs
+++ b/Abstractions/Config/RiskPreset.cs
@@ -1,0 +1,4 @@
+namespace NT8.SDK.Abstractions.Config
+{
+    public struct RiskPreset { public string Symbol; public int MaxContracts; public decimal DailyLossLimit; public decimal WeeklyLossLimit; public decimal TrailingDrawdown; }
+}

--- a/Abstractions/Config/RiskPresetLoader.cs
+++ b/Abstractions/Config/RiskPresetLoader.cs
@@ -1,0 +1,42 @@
+namespace NT8.SDK.Abstractions.Config
+{
+    using System;
+    using System.IO;
+    using System.Globalization;
+
+    public static class RiskPresetLoader
+    {
+        // Minimal JSON loader (expects flat keys as provided above); no external deps.
+        public static RiskPreset LoadFromFile(string path)
+        {
+            var text = File.ReadAllText(path);
+            var rp = new RiskPreset();
+            rp.Symbol = ExtractString(text, "\"symbol\"");
+            rp.MaxContracts = ExtractInt(text, "\"maxContracts\"");
+            rp.DailyLossLimit = ExtractDecimal(text, "\"dailyLossLimit\"");
+            rp.WeeklyLossLimit = ExtractDecimal(text, "\"weeklyLossLimit\"");
+            rp.TrailingDrawdown = ExtractDecimal(text, "\"trailingDrawdown\"");
+            return rp;
+        }
+
+        private static string ExtractString(string json, string key)
+        {
+            int i = json.IndexOf(key); if (i < 0) return null;
+            i = json.IndexOf(':', i) + 1; if (i <= 0) return null;
+            int q1 = json.IndexOf('"', i) + 1; if (q1 <= 0) return null;
+            int q2 = json.IndexOf('"', q1); if (q2 <= 0) return null;
+            return json.Substring(q1, q2 - q1);
+        }
+        private static int ExtractInt(string json, string key) { return (int)ExtractDecimal(json, key); }
+        private static decimal ExtractDecimal(string json, string key)
+        {
+            int i = json.IndexOf(key); if (i < 0) return 0m;
+            i = json.IndexOf(':', i) + 1; if (i <= 0) return 0m;
+            int j = i;
+            while (j < json.Length && (char.IsDigit(json[j]) || json[j]=='.' || json[j]=='-' )) j++;
+            var s = json.Substring(i, j - i).Trim();
+            decimal d; if (!decimal.TryParse(s, NumberStyles.Any, CultureInfo.InvariantCulture, out d)) d = 0m;
+            return d;
+        }
+    }
+}

--- a/Config/risk_presets/CL.conservative.json
+++ b/Config/risk_presets/CL.conservative.json
@@ -1,0 +1,1 @@
+{"symbol":"CL","maxContracts":1,"dailyLossLimit":500,"weeklyLossLimit":1500,"trailingDrawdown":1500}

--- a/Config/risk_presets/ES.conservative.json
+++ b/Config/risk_presets/ES.conservative.json
@@ -1,0 +1,1 @@
+{"symbol":"ES","maxContracts":1,"dailyLossLimit":500,"weeklyLossLimit":1500,"trailingDrawdown":1500}

--- a/Config/risk_presets/GC.conservative.json
+++ b/Config/risk_presets/GC.conservative.json
@@ -1,0 +1,1 @@
+{"symbol":"GC","maxContracts":1,"dailyLossLimit":400,"weeklyLossLimit":1200,"trailingDrawdown":1000}

--- a/Config/risk_presets/MES.conservative.json
+++ b/Config/risk_presets/MES.conservative.json
@@ -1,0 +1,1 @@
+{"symbol":"MES","maxContracts":1,"dailyLossLimit":100,"weeklyLossLimit":300,"trailingDrawdown":300}

--- a/Config/risk_presets/MNQ.conservative.json
+++ b/Config/risk_presets/MNQ.conservative.json
@@ -1,0 +1,1 @@
+{"symbol":"MNQ","maxContracts":1,"dailyLossLimit":150,"weeklyLossLimit":450,"trailingDrawdown":400}

--- a/Config/risk_presets/NQ.conservative.json
+++ b/Config/risk_presets/NQ.conservative.json
@@ -1,0 +1,1 @@
+{"symbol":"NQ","maxContracts":1,"dailyLossLimit":800,"weeklyLossLimit":2400,"trailingDrawdown":2200}


### PR DESCRIPTION
## Summary
- add portable RiskPreset struct and minimal file loader
- include conservative risk preset JSONs for ES/NQ/MES/MNQ/CL/GC

## Testing
- `pwsh -NoLogo -File tools/guard.ps1` *(fails: Missing QA summary: qa/summary.json)*
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68a2c60258988329be1f4f48d660d3d1