### PR TITLE
feat(strategy): add trading window gating (HHmmss) to RiskDelegatedStrategy

### DIFF
--- a/NT8Strategies/Live/RiskDelegatedStrategy.cs
+++ b/NT8Strategies/Live/RiskDelegatedStrategy.cs
@@ -99,6 +99,18 @@ namespace NinjaTrader.NinjaScript.Strategies
         [Display(Name = "BarsRequiredToTrade", Order = 7, GroupName = "Diagnostics")]
         public int BarsRequiredToTradeParam { get; set; }
 
+        [NinjaScriptProperty]
+        [Display(Name="UseTradingWindow", Order=20, GroupName="Trading Window")]
+        public bool UseTradingWindow { get; set; }
+
+        [NinjaScriptProperty, Range(0, 235959)]
+        [Display(Name="TradingWindowStart", Order=21, GroupName="Trading Window")]
+        public int TradingWindowStart { get; set; } // e.g., 93000 for 09:30:00
+
+        [NinjaScriptProperty, Range(0, 235959)]
+        [Display(Name="TradingWindowEnd", Order=22, GroupName="Trading Window")]
+        public int TradingWindowEnd { get; set; }   // e.g., 160000 for 16:00:00
+
         protected override void OnStateChange()
         {
             if (State == State.SetDefaults)
@@ -120,6 +132,9 @@ namespace NinjaTrader.NinjaScript.Strategies
                 UseAccountFlatten = true;
                 DebugMode = false;
                 BarsRequiredToTradeParam = 20;
+                UseTradingWindow = false;
+                TradingWindowStart = 93000;
+                TradingWindowEnd = 160000;
             }
             else if (State == State.Configure)
             {
@@ -202,6 +217,13 @@ namespace NinjaTrader.NinjaScript.Strategies
             if (CurrentBar < BarsRequiredToTrade) return;
             if (CurrentBar < BarsRequiredToTradeParam) return;
 
+            if (!IsInTradingWindow())
+            {
+                if (DebugMode) Print("[Window] Outside trading window. Blocking entries.");
+                try { if (Account != null && Instrument != null) Account.CancelAllOrders(Instrument); } catch {}
+                return; // skip entries when outside window
+            }
+
             MaintainAnchors();
             UpdatePeak();
             if (Enforce()) return;
@@ -218,6 +240,18 @@ namespace NinjaTrader.NinjaScript.Strategies
             if (State != State.Realtime) return;
             MaintainAnchors();
             UpdatePeak();
+            if (!IsInTradingWindow())
+            {
+                if (DebugMode) Print("[Window] Outside trading window (MD).");
+                try
+                {
+                    if (Account != null && Instrument != null) Account.CancelAllOrders(Instrument);
+                    if (UseAccountFlatten && Account != null && PositionAccount != null && PositionAccount.MarketPosition != MarketPosition.Flat)
+                        Account.FlattenEverything();
+                }
+                catch (Exception ex) { if (DebugMode) Print("[Window Flatten Error] " + ex.Message); }
+                return;
+            }
             Enforce();
         }
 
@@ -271,6 +305,21 @@ namespace NinjaTrader.NinjaScript.Strategies
                 if (DebugMode) Print("[RiskEnforceError] " + ex.Message);
             }
             return true;
+        }
+
+        private bool IsInTradingWindow()
+        {
+            try
+            {
+                if (!UseTradingWindow) return true;
+                int t = ToTime(Time[0]);
+                // allow wrap-around windows if End < Start
+                if (TradingWindowEnd >= TradingWindowStart)
+                    return t >= TradingWindowStart && t <= TradingWindowEnd;
+                else
+                    return (t >= TradingWindowStart) || (t <= TradingWindowEnd);
+            }
+            catch { return true; }
         }
 
         private void MaintainAnchors()


### PR DESCRIPTION
## Summary
- add HHmmss-based trading window parameters to RiskDelegatedStrategy
- skip and flatten positions outside window

## Testing
- `pwsh -File tools/guard.ps1` *(fails: command not found)*
- `python3 tools/nt8_guard.py`


------
https://chatgpt.com/codex/tasks/task_e_68a2c883c4048329b4913cc0b1e2b941