### PR TITLE
feat(strategy): persist daily/weekly PnL anchors in RiskDelegatedStrategy

### DIFF
--- a/NT8Strategies/Live/RiskDelegatedStrategy.cs
+++ b/NT8Strategies/Live/RiskDelegatedStrategy.cs
@@ -1,6 +1,8 @@
 #region Using declarations
 using System;
 using System.Reflection;
+using System.IO;
+using System.Globalization;
 using NinjaTrader.Cbi;
 using NinjaTrader.Data;
 using NinjaTrader.Gui.Tools;
@@ -129,7 +131,12 @@ namespace NinjaTrader.NinjaScript.Strategies
             {
                 dayBase = Cum(); weekBase = Cum(); peak = Cum();
                 weekAnchor = WeekAnchor(Time[0].Date);
+                LoadAnchors();
                 TryHookSdk();
+            }
+            else if (State == State.Terminated)
+            {
+                SaveAnchors();
             }
         }
 
@@ -298,6 +305,65 @@ namespace NinjaTrader.NinjaScript.Strategies
             int diff = (int)d.DayOfWeek - (int)DayOfWeek.Monday;
             if (diff < 0) diff += 7;
             return d.AddDays(-diff);
+        }
+
+        private string GetStoreDir()
+        {
+            try {
+                var doc = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+                var dir = Path.Combine(doc, "NinjaTrader 8", "RiskAnchors");
+                if (!Directory.Exists(dir)) Directory.CreateDirectory(dir);
+                return dir;
+            } catch { return null; }
+        }
+
+        private string GetStorePath()
+        {
+            try {
+                var dir = GetStoreDir();
+                var instr = (Instrument!=null && Instrument.MasterInstrument!=null)?Instrument.MasterInstrument.Name:"UNKNOWN";
+                var acct = (Account!=null && !string.IsNullOrEmpty(Account.Name))?Account.Name:"UNKN";
+                return dir==null? null : Path.Combine(dir, instr+"_"+acct+".anchors.json");
+            } catch { return null; }
+        }
+
+        private static bool TryExtractDouble(string json, string key, out double val)
+        {
+            val = 0.0;
+            try {
+                int i = json.IndexOf(key); if (i < 0) return false;
+                i = json.IndexOf(':', i) + 1; if (i <= 0) return false;
+                int j = i; while (j < json.Length && "-0123456789.eE".IndexOf(json[j])>=0) j++;
+                var s = json.Substring(i, j - i).Trim();
+                return double.TryParse(s, NumberStyles.Any, CultureInfo.InvariantCulture, out val);
+            } catch { return false; }
+        }
+
+        private void LoadAnchors()
+        {
+            try {
+                var path = GetStorePath(); if (string.IsNullOrEmpty(path) || !File.Exists(path)) return;
+                var json = File.ReadAllText(path);
+                double d,w,p;
+                if (TryExtractDouble(json,"\"dayBase\"",out d)) dayBase = d;
+                if (TryExtractDouble(json,"\"weekBase\"",out w)) weekBase = w;
+                if (TryExtractDouble(json,"\"peak\"",out p)) peak = p;
+                if (DebugMode) Print("[Anchors] Loaded " + path + $" dayBase={dayBase:0.00} weekBase={weekBase:0.00} peak={peak:0.00}");
+            } catch (Exception ex) { if (DebugMode) Print("[Anchors Load Error] " + ex.Message); }
+        }
+
+        private void SaveAnchors()
+        {
+            try {
+                var path = GetStorePath(); if (string.IsNullOrEmpty(path)) return;
+                var s = "{"
+                  + "\"dayBase\":" + dayBase.ToString(CultureInfo.InvariantCulture) + ","
+                  + "\"weekBase\":" + weekBase.ToString(CultureInfo.InvariantCulture) + ","
+                  + "\"peak\":" + peak.ToString(CultureInfo.InvariantCulture)
+                  + "}";
+                File.WriteAllText(path, s);
+                if (DebugMode) Print("[Anchors] Saved " + path);
+            } catch (Exception ex) { if (DebugMode) Print("[Anchors Save Error] " + ex.Message); }
         }
 
         // === Contract signatures ===


### PR DESCRIPTION
## Summary
- persist RiskDelegatedStrategy daily/weekly PnL anchors and peak across restarts
- load anchors in DataLoaded and save on Terminated

## Testing
- `pwsh -NoLogo -NoProfile -Command "./tools/ninjascript_lint.ps1 -Path NT8Strategies/Live/RiskDelegatedStrategy.cs"` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: Unable to locate package powershell)*

------
https://chatgpt.com/codex/tasks/task_e_68a2c9ba18688329ae9eb6bbcfb40ce4